### PR TITLE
Merge with DOLFINx main into non-matching mesh interpolation

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -27,6 +27,9 @@ jobs:
         os: [ubuntu-20.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      CC: gcc-10
+      CXX: g++-10
 
     steps:
       - name: Get Spack

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,40 +1,39 @@
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Top level CMakeLists.txt file for DOLFINx
 cmake_minimum_required(VERSION 3.16)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Set project name and version number
-
 project(DOLFINX VERSION "0.4.2.0")
 
 set(DOXYGEN_DOLFINX_VERSION ${DOLFINX_VERSION} CACHE STRING "Version for Doxygen" FORCE)
 
-#------------------------------------------------------------------------------
-# Use C++17
-set(CMAKE_CXX_STANDARD 17)
+# ------------------------------------------------------------------------------
+# Use C++20
+set(CMAKE_CXX_STANDARD 20)
 
-# Require C++17
+# Require C++20
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Do not enable compler-specific extensions
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Get GIT changeset, if available
-
 find_program(GIT_FOUND git)
-if (GIT_FOUND)
+
+if(GIT_FOUND)
   # Get the commit hash of the working branch
   execute_process(COMMAND git rev-parse HEAD
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_COMMIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+  )
 else()
   set(GIT_COMMIT_HASH "unknown")
 endif()
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # General configuration
 
 # Set location of our FindFoo.cmake modules
@@ -43,9 +42,8 @@ set(CMAKE_MODULE_PATH "${DOLFINX_SOURCE_DIR}/cmake/modules")
 # Make sure CMake uses the correct DOLFINConfig.cmake for tests and demos
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${CMAKE_CURRENT_BINARY_DIR}/dolfinx)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Configurable options for how we want to build
-
 include(FeatureSummary)
 
 option(BUILD_SHARED_LIBS "Build DOLFINx with shared libraries." ON)
@@ -58,10 +56,6 @@ add_feature_info(DOLFINX_SKIP_BUILD_TESTS DOLFINX_SKIP_BUILD_TESTS "Skip build t
 option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath." ON)
 add_feature_info(CMAKE_INSTALL_RPATH_USE_LINK_PATH CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath.")
 
-# Enable SIMD with xtensor
-option(XTENSOR_USE_XSIMD "Enable SIMD with xtensor." OFF)
-add_feature_info(XTENSOR_USE_XSIMD XTENSOR_USE_XSIMD "Enable SIMD with xtensor (xsimd).")
-
 # Enable xtensor with target-specific optimization, i.e. -march=native
 option(XTENSOR_OPTIMIZE "Enable xtensor target-specific optimization" OFF)
 add_feature_info(XTENSOR_OPTIMIZE XTENSOR_OPTIMIZE "Enable architecture-specific optimizations as defined by xtensor.")
@@ -70,7 +64,7 @@ add_feature_info(XTENSOR_OPTIMIZE XTENSOR_OPTIMIZE "Enable architecture-specific
 option(DOLFINX_UFCX_PYTHON "Enable UFCx discovery using Python. Disable if UFCx should be found using CMake." ON)
 add_feature_info(DOLFINX_UFCX_PYTHON DOLFINX_UFCX_PYTHON "Enable UFCx discovery using Python. Disable if UFCx should be found using a CMake config file.")
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Enable or disable optional packages
 
 # List optional packages
@@ -80,16 +74,15 @@ option(DOLFINX_ENABLE_SCOTCH "Compile with support for SCOTCH." ON)
 option(DOLFINX_ENABLE_SLEPC "Compile with support for SLEPc." ON)
 option(DOLFINX_ENABLE_KAHIP "Compile with support for KaHIP." OFF)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Check for MPI
-
 find_package(MPI 3 REQUIRED)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Compiler flags
 
 # Default build type (can be overridden by user)
-if (NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
     "Choose the type of build, options are: Debug Developer MinSizeRel Release RelWithDebInfo." FORCE)
 endif()
@@ -97,29 +90,33 @@ endif()
 # Check for some compiler flags
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-pipe HAVE_PIPE)
-if (HAVE_PIPE)
+
+if(HAVE_PIPE)
   list(APPEND DOLFINX_CXX_DEVELOPER_FLAGS -pipe)
 endif()
 
 # Add some strict compiler checks
 CHECK_CXX_COMPILER_FLAG("-Wall -Werror -Wextra -pedantic" HAVE_PEDANTIC)
-if (HAVE_PEDANTIC)
+
+if(HAVE_PEDANTIC)
   list(APPEND DOLFINX_CXX_DEVELOPER_FLAGS -Wall;-Werror;-Wextra;-pedantic)
 endif()
 
 # Debug flags
 CHECK_CXX_COMPILER_FLAG(-g HAVE_DEBUG)
-if (HAVE_DEBUG)
+
+if(HAVE_DEBUG)
   list(APPEND DOLFINX_CXX_DEVELOPER_FLAGS -g)
 endif()
 
 # Optimisation
 CHECK_CXX_COMPILER_FLAG(-O2 HAVE_O2_OPTIMISATION)
-if (HAVE_O2_OPTIMISATION)
+
+if(HAVE_O2_OPTIMISATION)
   list(APPEND DOLFINX_CXX_DEVELOPER_FLAGS -O2)
 endif()
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Find required packages
 
 # pugixml
@@ -129,6 +126,7 @@ find_package(pugixml REQUIRED)
 if(DEFINED ENV{BOOST_ROOT} OR DEFINED BOOST_ROOT)
   set(Boost_NO_SYSTEM_PATHS on)
 endif()
+
 set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
 set(Boost_VERBOSE TRUE)
 find_package(Boost 1.70 REQUIRED timer)
@@ -147,26 +145,21 @@ execute_process(
   OUTPUT_VARIABLE BASIX_PY_DIR
   RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (BASIX_PY_DIR)
-  message(STATUS "Adding ${BASIX_PY_DIR} to Basix/xtensor/xtl search hints")
-  set(xtl_ROOT "${BASIX_PY_DIR};${xtl_ROOT}")
-  set(xsimd "${BASIX_PY_DIR};${xsimd_ROOT}")
+
+if(BASIX_PY_DIR)
+  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
   set(xtensor_ROOT "${BASIX_PY_DIR};${xtensor_ROOT}")
 
   # Basix installed from manylinux wheel
-  if (IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
+  if(IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
     set(CMAKE_INSTALL_RPATH ${BASIX_PY_DIR}/../fenics_basix.libs)
   endif()
 endif()
+
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 set_package_properties(basix PROPERTIES TYPE REQUIRED
   DESCRIPTION "FEniCS tabulation library"
   URL "https://github.com/fenics/basix")
-
-get_target_property(BASIX_DEFN Basix::basix INTERFACE_COMPILE_DEFINITIONS)
-if("XTENSOR_USE_XSIMD" IN_LIST BASIX_DEFN)
-  find_package(xsimd REQUIRED)
-endif()
 
 # Check for xtensor
 find_package(xtensor 0.23.10 REQUIRED)
@@ -191,6 +184,7 @@ if(PETSC_FOUND)
 else()
   set_property(GLOBAL APPEND PROPERTY PACKAGES_NOT_FOUND PETSc)
 endif()
+
 set_package_properties(PETSc PROPERTIES TYPE REQUIRED
   DESCRIPTION "Portable, Extensible Toolkit for Scientific Computation (PETSc)"
   URL "https://www.mcs.anl.gov/petsc/"
@@ -200,9 +194,11 @@ set_package_properties(PETSc PROPERTIES TYPE REQUIRED
 set(HDF5_PREFER_PARALLEL TRUE)
 set(HDF5_FIND_DEBUG TRUE)
 find_package(HDF5 REQUIRED COMPONENTS C)
-if (NOT HDF5_IS_PARALLEL)
+
+if(NOT HDF5_IS_PARALLEL)
   message(FATAL_ERROR "Found serial HDF5 build, MPI HDF5 build required, try setting HDF5_DIR or HDF5_ROOT")
 endif()
+
 set_package_properties(HDF5 PROPERTIES TYPE REQUIRED
   DESCRIPTION "Hierarchical Data Format 5 (HDF5)"
   URL "https://www.hdfgroup.org/HDF5")
@@ -210,7 +206,7 @@ set_package_properties(HDF5 PROPERTIES TYPE REQUIRED
 # Check for UFC
 # Note: we use the case (ufcx vs UFCx) elsewhere to determine by which
 # method UFCx was found
-if (NOT DOLFINX_UFCX_PYTHON)
+if(NOT DOLFINX_UFCX_PYTHON)
   # Check in CONFIG mode, i.e. look for instaled ufcxConfig.cmake
   find_package(ufcx ${DOLFINX_VERSION_MAJOR}.${DOLFINX_VERSION_MINOR} REQUIRED CONFIG)
 else()
@@ -218,22 +214,23 @@ else()
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   find_package(UFCx ${DOLFINX_VERSION_MAJOR}.${DOLFINX_VERSION_MINOR} REQUIRED MODULE)
 endif()
+
 set_package_properties(UFCx PROPERTIES TYPE REQUIRED
   DESCRIPTION "Interface for form-compilers (part of FFCx)"
   URL "https://github.com/fenics/ffcx")
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Find optional packages
-
-if (DOLFINX_ENABLE_ADIOS2)
-  find_package(ADIOS2 2.7.1)
+if(DOLFINX_ENABLE_ADIOS2)
+  find_package(ADIOS2 2.8.1)
 endif()
+
 set_package_properties(ADIOS2 PROPERTIES TYPE OPTIONAL
   DESCRIPTION "Adaptable Input/Output (I/O) System."
   URL "https://adios2.readthedocs.io/en/latest/"
   PURPOSE "IO, including in parallel")
 
-if (DOLFINX_ENABLE_SLEPC)
+if(DOLFINX_ENABLE_SLEPC)
   find_package(PkgConfig REQUIRED)
   set(ENV{PKG_CONFIG_PATH} "$ENV{SLEPC_DIR}/$ENV{PETSC_ARCH}/lib/pkgconfig:$ENV{SLEPC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
   set(ENV{PKG_CONFIG_PATH} "$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}/lib/pkgconfig:$ENV{PETSC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
@@ -247,55 +244,57 @@ if (DOLFINX_ENABLE_SLEPC)
     set_property(GLOBAL APPEND PROPERTY PACKAGES_NOT_FOUND SLEPc)
   endif()
 endif()
+
 set_package_properties(SLEPc PROPERTIES TYPE RECOMMENDED
   DESCRIPTION "Scalable Library for Eigenvalue Problem Computations"
   URL "http://slepc.upv.es/"
   PURPOSE "Eigenvalue computation")
 
-if (DOLFINX_ENABLE_SCOTCH)
+if(DOLFINX_ENABLE_SCOTCH)
   find_package(SCOTCH)
 endif()
+
 set_package_properties(SCOTCH PROPERTIES TYPE OPTIONAL
   DESCRIPTION "Programs and libraries for graph, mesh and hypergraph partitioning"
   URL "https://www.labri.fr/perso/pelegrin/scotch"
   PURPOSE "Parallel graph partitioning")
 
-if (DOLFINX_ENABLE_PARMETIS)
+if(DOLFINX_ENABLE_PARMETIS)
   find_package(ParMETIS 4.0.2)
 endif()
+
 set_package_properties(ParMETIS PROPERTIES TYPE RECOMMENDED
   DESCRIPTION "Parallel Graph Partitioning and Fill-reducing Matrix Ordering"
   URL "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview"
   PURPOSE "Parallel graph partitioning")
 
-if (DOLFINX_ENABLE_KAHIP)
+if(DOLFINX_ENABLE_KAHIP)
   find_package(KaHIP)
 endif()
+
 set_package_properties(KaHIP PROPERTIES TYPE OPTIONAL
   DESCRIPTION "A family of graph partitioning programs"
   URL "https://kahip.github.io/"
   PURPOSE "Parallel graph partitioning")
 
 # Check that at least one graph partitioner has been found
-if (NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KAHIP_FOUND)
+if(NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KAHIP_FOUND)
   message(FATAL_ERROR "No graph partitioner found. SCOTCH, ParMETIS or KaHIP is required.")
 endif()
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Print summary of found and not found optional packages
-
 feature_summary(WHAT ALL)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Installation of DOLFINx library
-
 add_subdirectory(dolfinx)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Generate and install helper file dolfinx.conf
 
 # FIXME: Can CMake provide the library path name variable?
-if (APPLE)
+if(APPLE)
   set(OS_LIBRARY_PATH_NAME "DYLD_LIBRARY_PATH")
 else()
   set(OS_LIBRARY_PATH_NAME "LD_LIBRARY_PATH")
@@ -304,21 +303,21 @@ endif()
 # FIXME: not cross-platform compatible
 # Create and install dolfinx.conf file
 configure_file(${DOLFINX_SOURCE_DIR}/cmake/templates/dolfinx.conf.in
-               ${CMAKE_BINARY_DIR}/dolfinx.conf @ONLY)
+  ${CMAKE_BINARY_DIR}/dolfinx.conf @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/dolfinx.conf
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/dolfinx
-        COMPONENT Development)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/dolfinx
+  COMPONENT Development)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Copy data in demo/test direcories to the build directories
-
 set(GENERATE_DEMO_TEST_DATA FALSE)
-if (Python3_Interpreter_FOUND AND (${DOLFINX_SOURCE_DIR}/demo IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/demo OR ${DOLFINX_SOURCE_DIR}/test IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/test))
+
+if(Python3_Interpreter_FOUND AND(${DOLFINX_SOURCE_DIR}/demo IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/demo OR ${DOLFINX_SOURCE_DIR}/test IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/test))
   file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/demo ${CMAKE_CURRENT_BINARY_DIR}/test)
   set(GENERATE_DEMO_TEST_DATA TRUE)
 endif()
 
-if (GENERATE_DEMO_TEST_DATA)
+if(GENERATE_DEMO_TEST_DATA)
   message(STATUS "")
   message(STATUS "Copying demo and test data to build directory.")
   message(STATUS "----------------------------------------------")
@@ -328,12 +327,13 @@ if (GENERATE_DEMO_TEST_DATA)
     RESULT_VARIABLE COPY_DEMO_DATA_RESULT
     OUTPUT_VARIABLE COPY_DEMO_DATA_OUTPUT
     ERROR_VARIABLE COPY_DEMO_DATA_OUTPUT)
-  if (COPY_DEMO_DATA_RESULT)
+
+  if(COPY_DEMO_DATA_RESULT)
     message(FATAL_ERROR "Copy demo data failed: \n${COPY_DEMO_DATA_OUTPUT}")
   endif()
 endif()
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Install the demo source files
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/demo DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dolfinx
   FILES_MATCHING
@@ -347,9 +347,8 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/demo DESTINATION ${CMAKE_INSTALL_D
   PATTERN "*.h5"
   PATTERN "CMakeFiles" EXCLUDE)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Add "make uninstall" target
-
 configure_file(
   "${DOLFINX_SOURCE_DIR}/cmake/templates/cmake_uninstall.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
@@ -358,9 +357,8 @@ configure_file(
 add_custom_target(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Print post-install message
-
 add_subdirectory(cmake/post-install)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------

--- a/cpp/cmake/scripts/generate-cmakefiles.py
+++ b/cpp/cmake/scripts/generate-cmakefiles.py
@@ -17,8 +17,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME {project_name})
 project(${{PROJECT_NAME}} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -56,8 +56,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME {project_name})
 project(${{PROJECT_NAME}} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -75,7 +75,7 @@ else()
     VERBATIM DEPENDS {ufl_files} COMMENT "Compile {ufl_files} using FFCx")
 
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
-  
+
   add_executable(${{PROJECT_NAME}} {src_files} ${{CMAKE_CURRENT_BINARY_DIR}}/{ufl_c_files})
   target_link_libraries(${{PROJECT_NAME}} dolfinx)
 
@@ -104,8 +104,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME {project_name})
 project(${{PROJECT_NAME}} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cpp/demo/hyperelasticity/CMakeLists.txt
+++ b/cpp/demo/hyperelasticity/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME demo_hyperelasticity)
 project(${PROJECT_NAME} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cpp/demo/hyperelasticity/CMakeLists.txt
+++ b/cpp/demo/hyperelasticity/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     VERBATIM DEPENDS hyperelasticity.py COMMENT "Compile hyperelasticity.py using FFCx")
 
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
-  
+
   add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/hyperelasticity.c)
   target_link_libraries(${PROJECT_NAME} dolfinx)
 

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -60,7 +60,7 @@ public:
     return [&](const Vec x, Vec)
     {
       // Assemble b and update ghosts
-      xtl::span<T> b(_b.mutable_array());
+      std::span<T> b(_b.mutable_array());
       std::fill(b.begin(), b.end(), 0.0);
       fem::assemble_vector<T>(b, *_l);
       VecGhostUpdateBegin(_b_petsc, ADD_VALUES, SCATTER_REVERSE);
@@ -73,7 +73,7 @@ public:
       VecGetSize(x_local, &n);
       const T* array = nullptr;
       VecGetArrayRead(x_local, &array);
-      fem::set_bc<T>(b, _bcs, xtl::span<const T>(array, n), -1.0);
+      fem::set_bc<T>(b, _bcs, std::span<const T>(array, n), -1.0);
       VecRestoreArrayRead(x, &array);
     };
   }

--- a/cpp/demo/interpolation-io/CMakeLists.txt
+++ b/cpp/demo/interpolation-io/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME demo_interpolation-io)
 project(${PROJECT_NAME} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -17,6 +17,8 @@
 #include <dolfinx/mesh/generation.h>
 #include <filesystem>
 #include <mpi.h>
+#include <numbers>
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 
@@ -41,7 +43,7 @@ void interpolate_scalar(const std::shared_ptr<mesh::Mesh>& mesh,
 
   // Interpolate sin(2 \pi x[0]) in the scalar Lagrange finite element
   // space
-  constexpr double PI = xt::numeric_constants<double>::PI;
+  constexpr double PI = std::numbers::pi;
   u->interpolate([PI](auto&& x) { return xt::sin(2 * PI * xt::row(x, 0)); });
 
   // Write the function to a VTK file for visualisation, e.g. using

--- a/cpp/demo/interpolation/CMakeLists.txt
+++ b/cpp/demo/interpolation/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME demo_interpolation)
 project(${PROJECT_NAME} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cpp/demo/poisson/CMakeLists.txt
+++ b/cpp/demo/poisson/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME demo_poisson)
 project(${PROJECT_NAME} LANGUAGES C CXX)
 
-# Set standard
+# Set C++20 standard
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/cpp/demo/poisson/CMakeLists.txt
+++ b/cpp/demo/poisson/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME demo_poisson)
 project(${PROJECT_NAME} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cpp/demo/poisson_matrix_free/CMakeLists.txt
+++ b/cpp/demo/poisson_matrix_free/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME demo_poisson_matrix_free)
 project(${PROJECT_NAME} LANGUAGES C CXX)
 
-# Set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cpp/demo/poisson_matrix_free/main.cpp
+++ b/cpp/demo/poisson_matrix_free/main.cpp
@@ -31,6 +31,7 @@
 #include <dolfinx.h>
 #include <dolfinx/fem/Constant.h>
 #include <xtensor/xarray.hpp>
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 
@@ -45,7 +46,7 @@ template <typename U>
 void axpy(la::Vector<U>& r, U alpha, const la::Vector<U>& x,
           const la::Vector<U>& y)
 {
-  std::transform(x.array().cbegin(), x.array().cend(), y.array().cbegin(),
+  std::transform(x.array().begin(), x.array().end(), y.array().begin(),
                  r.mutable_array().begin(),
                  [alpha](auto x, auto y) { return alpha * x + y; });
 }
@@ -189,7 +190,7 @@ int main(int argc, char* argv[])
 
       // Compute action of A on x
       fem::pack_coefficients(*M, coeff);
-      fem::assemble_vector(y.mutable_array(), *M, xtl::span<const T>(constants),
+      fem::assemble_vector(y.mutable_array(), *M, std::span<const T>(constants),
                            fem::make_coefficients_span(coeff));
 
       // Set BC dofs to zero (effectively zeroes rows of A)

--- a/cpp/doc/source/fem.rst
+++ b/cpp/doc/source/fem.rst
@@ -79,11 +79,11 @@ Interpolation
 .. doxygenfunction:: dolfinx::fem::interpolation_coords
    :project: DOLFINx
 
-.. doxygenfunction:: dolfinx::fem::interpolate(Function<T> &u, const Function<T> &v, const xtl::span<const std::int32_t> &cells)
+.. doxygenfunction:: dolfinx::fem::interpolate(Function<T> &u, const Function<T> &v, const std::span<const std::int32_t> &cells)
    :project: DOLFINx
 
 
-.. doxygenfunction:: dolfinx::fem::interpolate(Function<T> &u, const xt::xarray<T> &f, const xtl::span<const std::int32_t> &cells)
+.. doxygenfunction:: dolfinx::fem::interpolate(Function<T> &u, const xt::xarray<T> &f, const std::span<const std::int32_t> &cells)
    :project: DOLFINx
 
 

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -67,14 +67,7 @@ endif()
 target_link_libraries(dolfinx PUBLIC Basix::basix)
 
 # xtensor
-target_link_libraries(dolfinx PUBLIC xtl)
 target_link_libraries(dolfinx PUBLIC xtensor)
-if("XTENSOR_USE_XSIMD" IN_LIST BASIX_DEFN)
-  target_link_libraries(dolfinx PUBLIC xsimd)
-endif()
-if(XTENSOR_OPTIMIZE)
-  target_link_libraries(dolfinx PUBLIC xtensor::optimize)
-endif()
 
 # Boost
 target_link_libraries(dolfinx PUBLIC Boost::headers)

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -8,6 +8,7 @@
 #include "sort.h"
 #include <algorithm>
 #include <functional>
+#include <map>
 #include <numeric>
 
 using namespace dolfinx;
@@ -16,7 +17,7 @@ using namespace dolfinx::common;
 namespace
 {
 std::array<std::vector<int>, 2>
-build_src_dest(MPI_Comm comm, const xtl::span<const int>& owners)
+build_src_dest(MPI_Comm comm, const std::span<const int>& owners)
 {
   std::vector<int> src(owners.begin(), owners.end());
   std::sort(src.begin(), src.end());
@@ -32,7 +33,7 @@ build_src_dest(MPI_Comm comm, const xtl::span<const int>& owners)
 
 //-----------------------------------------------------------------------------
 std::vector<int32_t> dolfinx::common::compute_owned_indices(
-    const xtl::span<const std::int32_t>& indices, const IndexMap& map)
+    const std::span<const std::int32_t>& indices, const IndexMap& map)
 {
   // Build list of (owner, index) pairs for each ghost in indices, and
   // sort
@@ -317,8 +318,8 @@ IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size)
 }
 //-----------------------------------------------------------------------------
 IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size,
-                   const xtl::span<const std::int64_t>& ghosts,
-                   const xtl::span<const int>& owners)
+                   const std::span<const std::int64_t>& ghosts,
+                   const std::span<const int>& owners)
     : IndexMap(comm, local_size, build_src_dest(comm, owners), ghosts, owners)
 {
   // Do nothing
@@ -326,8 +327,8 @@ IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size,
 //-----------------------------------------------------------------------------
 IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size,
                    const std::array<std::vector<int>, 2>& src_dest,
-                   const xtl::span<const std::int64_t>& ghosts,
-                   const xtl::span<const int>& owners)
+                   const std::span<const std::int64_t>& ghosts,
+                   const std::span<const int>& owners)
     : _comm(comm), _ghosts(ghosts.begin(), ghosts.end()),
       _owners(owners.begin(), owners.end()), _src(src_dest[0]),
       _dest(src_dest[1]), _overlapping(true)
@@ -375,13 +376,13 @@ const std::vector<std::int64_t>& IndexMap::ghosts() const noexcept
   return _ghosts;
 }
 //-----------------------------------------------------------------------------
-void IndexMap::local_to_global(const xtl::span<const std::int32_t>& local,
-                               const xtl::span<std::int64_t>& global) const
+void IndexMap::local_to_global(const std::span<const std::int32_t>& local,
+                               const std::span<std::int64_t>& global) const
 {
   assert(local.size() <= global.size());
   const std::int32_t local_size = _local_range[1] - _local_range[0];
   std::transform(
-      local.cbegin(), local.cend(), global.begin(),
+      local.begin(), local.end(), global.begin(),
       [local_size, local_range = _local_range[0], &ghosts = _ghosts](auto local)
       {
         if (local < local_size)
@@ -394,8 +395,8 @@ void IndexMap::local_to_global(const xtl::span<const std::int32_t>& local,
       });
 }
 //-----------------------------------------------------------------------------
-void IndexMap::global_to_local(const xtl::span<const std::int64_t>& global,
-                               const xtl::span<std::int32_t>& local) const
+void IndexMap::global_to_local(const std::span<const std::int64_t>& global,
+                               const std::span<std::int32_t>& local) const
 {
   const std::int32_t local_size = _local_range[1] - _local_range[0];
 
@@ -406,7 +407,7 @@ void IndexMap::global_to_local(const xtl::span<const std::int64_t>& global,
   std::map<std::int64_t, std::int32_t> global_to_local(
       global_local_ghosts.begin(), global_local_ghosts.end());
 
-  std::transform(global.cbegin(), global.cend(), local.begin(),
+  std::transform(global.begin(), global.end(), local.begin(),
                  [range = _local_range,
                   &global_to_local](std::int64_t index) -> std::int32_t
                  {
@@ -436,7 +437,7 @@ std::vector<std::int64_t> IndexMap::global_indices() const
 MPI_Comm IndexMap::comm() const { return _comm.comm(); }
 //----------------------------------------------------------------------------
 std::pair<IndexMap, std::vector<std::int32_t>>
-IndexMap::create_submap(const xtl::span<const std::int32_t>& indices) const
+IndexMap::create_submap(const std::span<const std::int32_t>& indices) const
 {
   if (!indices.empty() and indices.back() >= this->size_local())
   {
@@ -717,7 +718,7 @@ graph::AdjacencyList<int> IndexMap::index_to_dest_ranks() const
       std::vector<std::vector<std::int64_t>> dest_idx_to_rank(dest.size());
       for (std::size_t n = 0; n < offsets.size() - 1; ++n)
       {
-        xtl::span<const std::int32_t> ranks(data.data() + offsets[n],
+        std::span<const std::int32_t> ranks(data.data() + offsets[n],
                                             offsets[n + 1] - offsets[n]);
         for (auto r0 : ranks)
         {

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -10,9 +10,9 @@
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <memory>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::common
 {
@@ -27,7 +27,7 @@ class IndexMap;
 /// @param[in] map The index map
 /// @return Indices owned by the calling process
 std::vector<int32_t>
-compute_owned_indices(const xtl::span<const std::int32_t>& indices,
+compute_owned_indices(const std::span<const std::int32_t>& indices,
                       const IndexMap& map);
 
 /// @brief Compute layout data and ghost indices for a stacked
@@ -89,8 +89,8 @@ public:
   /// @param[in] owners Owner rank (on global communicator) of each
   /// entry in `ghosts`
   IndexMap(MPI_Comm comm, std::int32_t local_size,
-           const xtl::span<const std::int64_t>& ghosts,
-           const xtl::span<const int>& owners);
+           const std::span<const std::int64_t>& ghosts,
+           const std::span<const int>& owners);
 
   /// @brief Create an overlapping (ghosted) index map.
   ///
@@ -113,8 +113,8 @@ public:
   /// in `ghosts`
   IndexMap(MPI_Comm comm, std::int32_t local_size,
            const std::array<std::vector<int>, 2>& src_dest,
-           const xtl::span<const std::int64_t>& ghosts,
-           const xtl::span<const int>& owners);
+           const std::span<const std::int64_t>& ghosts,
+           const std::span<const int>& owners);
 
   // Copy constructor
   IndexMap(const IndexMap& map) = delete;
@@ -154,16 +154,16 @@ public:
   /// @brief Compute global indices for array of local indices.
   /// @param[in] local Local indices
   /// @param[out] global The global indices
-  void local_to_global(const xtl::span<const std::int32_t>& local,
-                       const xtl::span<std::int64_t>& global) const;
+  void local_to_global(const std::span<const std::int32_t>& local,
+                       const std::span<std::int64_t>& global) const;
 
   /// @brief Compute local indices for array of global indices
   /// @param[in] global Global indices
   /// @param[out] local The local of the corresponding global index in
   /// 'global'. Returns -1 if the local index does not exist on this
   /// process.
-  void global_to_local(const xtl::span<const std::int64_t>& global,
-                       const xtl::span<std::int32_t>& local) const;
+  void global_to_local(const std::span<const std::int64_t>& global,
+                       const std::span<std::int32_t>& local) const;
 
   /// @brief Build list of indices with global indexing.
   /// @return The global index for all local indices (0, 1, 2, ...) on
@@ -189,7 +189,7 @@ public:
   /// position in the new map to the ghost position in the original
   /// (this) map
   std::pair<IndexMap, std::vector<std::int32_t>>
-  create_submap(const xtl::span<const std::int32_t>& indices) const;
+  create_submap(const std::span<const std::int32_t>& indices) const;
 
   /// @todo Aim to remove this function?
   ///

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -7,6 +7,7 @@
 #include "MPI.h"
 #include <algorithm>
 #include <dolfinx/common/log.h>
+#include <iostream>
 
 //-----------------------------------------------------------------------------
 dolfinx::MPI::Comm::Comm(MPI_Comm comm, bool duplicate)
@@ -89,7 +90,7 @@ int dolfinx::MPI::size(const MPI_Comm comm)
 //-----------------------------------------------------------------------------
 std::vector<int>
 dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm,
-                                      const xtl::span<const int>& edges)
+                                      const std::span<const int>& edges)
 {
   LOG(INFO)
       << "Computing communicaton graph edges (using PCX algorithm). Number "
@@ -149,7 +150,7 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm,
 //-----------------------------------------------------------------------------
 std::vector<int>
 dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
-                                      const xtl::span<const int>& edges)
+                                      const std::span<const int>& edges)
 {
   LOG(INFO)
       << "Computing communicaton graph edges (using NBX algorithm). Number "

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -15,10 +15,11 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <numeric>
 #include <set>
+#include <span>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 #define MPICH_IGNORE_CXX_SEEK 1
 #include <mpi.h>
@@ -147,7 +148,7 @@ constexpr int index_owner(int size, std::size_t index, std::size_t N)
 /// @param[in] edges Edges (ranks) from this rank (the caller).
 /// @return Ranks that have defined edges from them to this rank.
 std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
-                                         const xtl::span<const int>& edges);
+                                         const std::span<const int>& edges);
 
 /// @brief Determine incoming graph edges using the NBX consensus
 /// algorithm.
@@ -174,7 +175,7 @@ std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
 /// @param[in] edges Edges (ranks) from this rank (the caller).
 /// @return Ranks that have defined edges from them to this rank.
 std::vector<int> compute_graph_edges_nbx(MPI_Comm comm,
-                                         const xtl::span<const int>& edges);
+                                         const std::span<const int>& edges);
 
 /// @brief Distribute row data to 'post office' ranks.
 ///
@@ -197,7 +198,7 @@ std::vector<int> compute_graph_edges_nbx(MPI_Comm comm,
 /// for which the calling process is the post office
 template <typename T>
 std::pair<std::vector<std::int32_t>, std::vector<T>>
-distribute_to_postoffice(MPI_Comm comm, const xtl::span<const T>& x,
+distribute_to_postoffice(MPI_Comm comm, const std::span<const T>& x,
                          std::array<std::int64_t, 2> shape,
                          std::int64_t rank_offset);
 
@@ -224,8 +225,8 @@ distribute_to_postoffice(MPI_Comm comm, const xtl::span<const T>& x,
 /// @pre `shape1 > 0`
 template <typename T>
 std::vector<T> distribute_from_postoffice(
-    MPI_Comm comm, const xtl::span<const std::int64_t>& indices,
-    const xtl::span<const T>& x, std::array<std::int64_t, 2> shape,
+    MPI_Comm comm, const std::span<const std::int64_t>& indices,
+    const std::span<const T>& x, std::array<std::int64_t, 2> shape,
     std::int64_t rank_offset);
 
 /// @brief Distribute rows of a rectangular data array to ranks where
@@ -253,8 +254,8 @@ std::vector<T> distribute_from_postoffice(
 /// @pre `shape1 > 0`
 template <typename T>
 std::vector<T> distribute_data(MPI_Comm comm,
-                               const xtl::span<const std::int64_t>& indices,
-                               const xtl::span<const T>& x, int shape1);
+                               const std::span<const std::int64_t>& indices,
+                               const std::span<const T>& x, int shape1);
 
 template <typename T>
 struct dependent_false : std::false_type
@@ -299,7 +300,7 @@ constexpr MPI_Datatype mpi_type()
 //---------------------------------------------------------------------------
 template <typename T>
 std::pair<std::vector<std::int32_t>, std::vector<T>>
-distribute_to_postoffice(MPI_Comm comm, const xtl::span<const T>& x,
+distribute_to_postoffice(MPI_Comm comm, const std::span<const T>& x,
                          std::array<std::int64_t, 2> shape,
                          std::int64_t rank_offset)
 {
@@ -441,8 +442,8 @@ distribute_to_postoffice(MPI_Comm comm, const xtl::span<const T>& x,
 //---------------------------------------------------------------------------
 template <typename T>
 std::vector<T> distribute_from_postoffice(
-    MPI_Comm comm, const xtl::span<const std::int64_t>& indices,
-    const xtl::span<const T>& x, std::array<std::int64_t, 2> shape,
+    MPI_Comm comm, const std::span<const std::int64_t>& indices,
+    const std::span<const T>& x, std::array<std::int64_t, 2> shape,
     std::int64_t rank_offset)
 {
   common::Timer timer("Distribute row-wise data (scalable)");
@@ -644,8 +645,8 @@ std::vector<T> distribute_from_postoffice(
 //---------------------------------------------------------------------------
 template <typename T>
 std::vector<T> distribute_data(MPI_Comm comm,
-                               const xtl::span<const std::int64_t>& indices,
-                               const xtl::span<const T>& x, int shape1)
+                               const std::span<const std::int64_t>& indices,
+                               const std::span<const T>& x, int shape1)
 {
   assert(shape1 > 0);
   assert(x.size() % shape1 == 0);

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -9,8 +9,8 @@
 #include "MPI.h"
 #include <algorithm>
 #include <mpi.h>
+#include <span>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 using namespace dolfinx;
 
@@ -53,8 +53,8 @@ public:
   /// @param request The MPI request handle for tracking the status of
   /// the non-blocking communication
   template <typename T>
-  void scatter_fwd_begin(const xtl::span<const T>& send_buffer,
-                         const xtl::span<T>& recv_buffer,
+  void scatter_fwd_begin(const std::span<const T>& send_buffer,
+                         const std::span<T>& recv_buffer,
                          MPI_Request& request) const
   {
     // Return early if there are no incoming or outgoing edges
@@ -96,14 +96,14 @@ public:
   /// @param[in] request The MPI request handle for tracking the status
   /// of the send
   template <typename T, typename Functor>
-  void scatter_fwd_begin(const xtl::span<const T>& local_data,
-                         xtl::span<T> local_buffer, xtl::span<T> remote_buffer,
+  void scatter_fwd_begin(const std::span<const T>& local_data,
+                         std::span<T> local_buffer, std::span<T> remote_buffer,
                          Functor pack_fn, MPI_Request& request) const
   {
     assert(local_buffer.size() == _local_inds.size());
     assert(remote_buffer.size() == _remote_inds.size());
     pack_fn(local_data, _local_inds, local_buffer);
-    scatter_fwd_begin(xtl::span<const T>(local_buffer), remote_buffer, request);
+    scatter_fwd_begin(std::span<const T>(local_buffer), remote_buffer, request);
   }
 
   /// @brief Complete a non-blocking send from the local owner to
@@ -126,8 +126,8 @@ public:
   /// @param[in] request The MPI request handle for tracking the status
   /// of the send
   template <typename T, typename Functor>
-  void scatter_fwd_end(const xtl::span<const T>& remote_buffer,
-                       xtl::span<T> remote_data, Functor unpack_fn,
+  void scatter_fwd_end(const std::span<const T>& remote_buffer,
+                       std::span<T> remote_data, Functor unpack_fn,
                        MPI_Request& request) const
   {
     assert(remote_buffer.size() == _remote_inds.size());
@@ -149,8 +149,8 @@ public:
   /// number of ghosts in the index map multiplied by the block size.
   /// The data for each index is blocked.
   template <typename T>
-  void scatter_fwd(const xtl::span<const T>& local_data,
-                   xtl::span<T> remote_data) const
+  void scatter_fwd(const std::span<const T>& local_data,
+                   std::span<T> remote_data) const
   {
     MPI_Request request;
     std::vector<T> local_buffer(local_buffer_size(), 0);
@@ -160,8 +160,8 @@ public:
       for (std::size_t i = 0; i < idx.size(); ++i)
         out[i] = in[idx[i]];
     };
-    scatter_fwd_begin(local_data, xtl::span<T>(local_buffer),
-                      xtl::span<T>(remote_buffer), pack_fn, request);
+    scatter_fwd_begin(local_data, std::span<T>(local_buffer),
+                      std::span<T>(remote_buffer), pack_fn, request);
 
     auto unpack_fn = [](const auto& in, const auto& idx, auto& out, auto op)
     {
@@ -169,7 +169,7 @@ public:
         out[idx[i]] = op(out[idx[i]], in[i]);
     };
 
-    scatter_fwd_end(xtl::span<const T>(remote_buffer), remote_data, unpack_fn,
+    scatter_fwd_end(std::span<const T>(remote_buffer), remote_data, unpack_fn,
                     request);
   }
 
@@ -198,8 +198,8 @@ public:
   /// @param request The MPI request handle for tracking the status of
   /// the non-blocking communication
   template <typename T>
-  void scatter_rev_begin(const xtl::span<const T>& send_buffer,
-                         const xtl::span<T>& recv_buffer,
+  void scatter_rev_begin(const std::span<const T>& send_buffer,
+                         const std::span<T>& recv_buffer,
                          MPI_Request& request) const
   {
     // Return early if there are no incoming or outgoing edges
@@ -250,14 +250,14 @@ public:
   /// @param request The MPI request handle for tracking the status of
   /// the non-blocking communication
   template <typename T, typename Functor>
-  void scatter_rev_begin(const xtl::span<const T>& remote_data,
-                         xtl::span<T> remote_buffer, xtl::span<T> local_buffer,
+  void scatter_rev_begin(const std::span<const T>& remote_data,
+                         std::span<T> remote_buffer, std::span<T> local_buffer,
                          Functor pack_fn, MPI_Request& request) const
   {
     assert(local_buffer.size() == _local_inds.size());
     assert(remote_buffer.size() == _remote_inds.size());
     pack_fn(remote_data, _remote_inds, remote_buffer);
-    scatter_rev_begin(xtl::span<const T>(remote_buffer), local_buffer, request);
+    scatter_rev_begin(std::span<const T>(remote_buffer), local_buffer, request);
   }
 
   /// @brief End the reverse scatter communication, and unpack the received
@@ -280,8 +280,8 @@ public:
   /// @param[in] request The handle used when calling
   /// Scatterer::scatter_rev_begin
   template <typename T, typename Functor, typename BinaryOp>
-  void scatter_rev_end(const xtl::span<const T>& local_buffer,
-                       xtl::span<T> local_data, Functor unpack_fn, BinaryOp op,
+  void scatter_rev_end(const std::span<const T>& local_buffer,
+                       std::span<T> local_data, Functor unpack_fn, BinaryOp op,
                        MPI_Request& request)
   {
     assert(local_buffer.size() == _local_inds.size());
@@ -295,8 +295,8 @@ public:
   /// @brief Scatter data associated with ghost indices to ranks that
   /// own the indices.
   template <typename T, typename BinaryOp>
-  void scatter_rev(xtl::span<T> local_data,
-                   const xtl::span<const T>& remote_data, BinaryOp op)
+  void scatter_rev(std::span<T> local_data,
+                   const std::span<const T>& remote_data, BinaryOp op)
   {
     std::vector<T> local_buffer(local_buffer_size(), 0);
     std::vector<T> remote_buffer(remote_buffer_size(), 0);
@@ -311,9 +311,9 @@ public:
         out[idx[i]] = op(out[idx[i]], in[i]);
     };
     MPI_Request request;
-    scatter_rev_begin(remote_data, xtl::span<T>(remote_buffer),
-                      xtl::span<T>(local_buffer), pack_fn, request);
-    scatter_rev_end(xtl::span<const T>(local_buffer), local_data, unpack_fn, op,
+    scatter_rev_begin(remote_data, std::span<T>(remote_buffer),
+                      std::span<T>(local_buffer), pack_fn, request);
+    scatter_rev_end(std::span<const T>(local_buffer), local_data, unpack_fn, op,
                     request);
   }
 

--- a/cpp/dolfinx/common/TimeLogger.cpp
+++ b/cpp/dolfinx/common/TimeLogger.cpp
@@ -7,6 +7,7 @@
 #include "TimeLogger.h"
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/log.h>
+#include <iostream>
 #include <variant>
 
 using namespace dolfinx;

--- a/cpp/dolfinx/common/math.h
+++ b/cpp/dolfinx/common/math.h
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <array>
+#include <basix/mdspan.hpp>
 #include <cmath>
+#include <string>
 #include <type_traits>
-#include <xtensor/xfixed.hpp>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx::math
 {
@@ -20,21 +20,7 @@ namespace dolfinx::math
 /// @param v The second vector. It must has size 3.
 /// @return The cross product `u x v`. The type will be the same as `u`.
 template <typename U, typename V>
-std::array<typename U::value_type, 3> cross_new(const U& u, const V& v)
-{
-  assert(u.size() == 3);
-  assert(v.size() == 3);
-  return {u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2],
-          u[0] * v[1] - u[1] * v[0]};
-}
-
-/// Compute the cross product u x v
-/// @param u The first vector. It must has size 3.
-/// @param v The second vector. It must has size 3.
-/// @return The cross product `u x v`. The type will be the same as `u`.
-template <typename U, typename V>
-xt::xtensor_fixed<typename U::value_type, xt::xshape<3>> cross(const U& u,
-                                                               const V& v)
+std::array<typename U::value_type, 3> cross(const U& u, const V& v)
 {
   assert(u.size() == 3);
   assert(v.size() == 3);
@@ -76,7 +62,6 @@ auto det(const T* A, std::array<std::size_t, 2> shape)
   {
     // Leibniz formula combined with Kahan’s method for accurate
     // computation of 3 x 3 determinants
-
     T w0 = difference_of_products(A[3 + 1], A[3 + 2], A[3 * 2 + 1],
                                   A[2 * 3 + 2]);
     T w1 = difference_of_products(A[3], A[3 + 2], A[3 * 2], A[3 * 2 + 2]);
@@ -97,13 +82,13 @@ auto det(const T* A, std::array<std::size_t, 2> shape)
 /// @param[in] A The matrix tp compute the determinant of
 /// @return The determinate of @p A
 template <typename Matrix>
-auto det(const Matrix& A)
+auto det(Matrix A)
 {
-  using value_type = typename Matrix::value_type;
-  assert(A.shape(0) == A.shape(1));
-  assert(A.dimension() == 2);
+  static_assert(Matrix::rank() == 2, "Must be rank 2");
+  assert(A.extent(0) == A.extent(1));
 
-  const int nrows = A.shape(0);
+  using value_type = typename Matrix::value_type;
+  const int nrows = A.extent(0);
   switch (nrows)
   {
   case 1:
@@ -123,8 +108,8 @@ auto det(const Matrix& A)
   }
   default:
     throw std::runtime_error("math::det is not implemented for "
-                             + std::to_string(A.shape(0)) + "x"
-                             + std::to_string(A.shape(1)) + " matrices.");
+                             + std::to_string(A.extent(0)) + "x"
+                             + std::to_string(A.extent(1)) + " matrices.");
   }
 }
 
@@ -135,10 +120,13 @@ auto det(const Matrix& A)
 /// same shape as @p A.
 /// @warning This function does not check if A is invertible
 template <typename U, typename V>
-void inv(const U& A, V&& B)
+void inv(U A, V B)
 {
+  static_assert(U::rank() == 2, "Must be rank 2");
+  static_assert(V::rank() == 2, "Must be rank 2");
+
   using value_type = typename U::value_type;
-  const std::size_t nrows = A.shape(0);
+  const std::size_t nrows = A.extent(0);
   switch (nrows)
   {
   case 1:
@@ -176,8 +164,8 @@ void inv(const U& A, V&& B)
   }
   default:
     throw std::runtime_error("math::inv is not implemented for "
-                             + std::to_string(A.shape(0)) + "x"
-                             + std::to_string(A.shape(1)) + " matrices.");
+                             + std::to_string(A.extent(0)) + "x"
+                             + std::to_string(A.extent(1)) + " matrices.");
   }
 }
 
@@ -188,65 +176,85 @@ void inv(const U& A, V&& B)
 /// @param[in] transpose Computes C += A^T * B^T if false, otherwise
 /// computed C += A^T * B^T
 template <typename U, typename V, typename P>
-void dot(const U& A, const V& B, P&& C, bool transpose = false)
+void dot(U A, V B, P C, bool transpose = false)
 {
+  static_assert(U::rank() == 2, "Must be rank 2");
+  static_assert(V::rank() == 2, "Must be rank 2");
+  static_assert(P::rank() == 2, "Must be rank 2");
+
   if (transpose)
   {
-    assert(A.shape(0) == B.shape(1));
-    for (std::size_t i = 0; i < A.shape(1); i++)
-      for (std::size_t j = 0; j < B.shape(0); j++)
-        for (std::size_t k = 0; k < A.shape(0); k++)
+    assert(A.extent(0) == B.extent(1));
+    for (std::size_t i = 0; i < A.extent(1); i++)
+      for (std::size_t j = 0; j < B.extent(0); j++)
+        for (std::size_t k = 0; k < A.extent(0); k++)
           C(i, j) += A(k, i) * B(j, k);
   }
   else
   {
-    assert(A.shape(1) == B.shape(0));
-    for (std::size_t i = 0; i < A.shape(0); i++)
-      for (std::size_t j = 0; j < B.shape(1); j++)
-        for (std::size_t k = 0; k < A.shape(1); k++)
+    assert(A.extent(1) == B.extent(0));
+    for (std::size_t i = 0; i < A.extent(0); i++)
+      for (std::size_t j = 0; j < B.extent(1); j++)
+        for (std::size_t k = 0; k < A.extent(1); k++)
           C(i, j) += A(i, k) * B(k, j);
   }
 }
 
-/// Compute the left pseudo inverse of a rectangular matrix A (3x2, 3x1,
-/// or 2x1), such that pinv(A) * A = I
+/// @brief Compute the left pseudo inverse of a rectangular matrix `A`
+/// (3x2, 3x1, or 2x1), such that pinv(A) * A = I.
 /// @param[in] A The matrix to the compute the pseudo inverse of.
-/// @param[out] P The pseudo inverse of @p A. It must be pre-allocated
-/// with a size which is the transpose of the size of @p A.
-/// @warning The matrix @p A should be full rank
+/// @param[out] P The pseudo inverse of `A`. It must be pre-allocated
+/// with a size which is the transpose of the size of `A`.
+/// @pre The matrix `A` must be full rank
 template <typename U, typename V>
-void pinv(const U& A, V&& P)
+void pinv(U A, V P)
 {
-  auto shape = A.shape();
-  assert(shape[0] > shape[1]);
-  assert(P.shape(1) == shape[0]);
-  assert(P.shape(0) == shape[1]);
+  static_assert(U::rank() == 2, "Must be rank 2");
+  static_assert(V::rank() == 2, "Must be rank 2");
+
+  assert(A.extent(0) > A.extent(1));
+  assert(P.extent(1) == A.extent(0));
+  assert(P.extent(0) == A.extent(1));
   using T = typename U::value_type;
-  if (shape[1] == 2)
+  if (A.extent(1) == 2)
   {
-    xt::xtensor_fixed<T, xt::xshape<2, 3>> AT;
-    xt::xtensor_fixed<T, xt::xshape<2, 2>> ATA;
-    xt::xtensor_fixed<T, xt::xshape<2, 2>> Inv;
-    AT = xt::transpose(A);
-    std::fill(ATA.begin(), ATA.end(), 0.0);
-    std::fill(P.begin(), P.end(), 0.0);
+    namespace stdex = std::experimental;
+    std::array<T, 6> ATb;
+    std::array<T, 4> ATAb, Invb;
+    stdex::mdspan<T, stdex::extents<std::size_t, 2, 3>> AT(ATb.data(), 2, 3);
+    stdex::mdspan<T, stdex::extents<std::size_t, 2, 2>> ATA(ATAb.data(), 2, 2);
+    stdex::mdspan<T, stdex::extents<std::size_t, 2, 2>> Inv(Invb.data(), 2, 2);
+
+    for (std::size_t i = 0; i < AT.extent(0); ++i)
+      for (std::size_t j = 0; j < AT.extent(1); ++j)
+        AT(i, j) = A(j, i);
+
+    std::fill(ATAb.begin(), ATAb.end(), 0.0);
+    for (std::size_t i = 0; i < P.extent(0); ++i)
+      for (std::size_t j = 0; j < P.extent(1); ++j)
+        P(i, j) = 0;
 
     // pinv(A) = (A^T * A)^-1 * A^T
     dolfinx::math::dot(AT, A, ATA);
     dolfinx::math::inv(ATA, Inv);
     dolfinx::math::dot(Inv, AT, P);
   }
-  else if (shape[1] == 1)
+  else if (A.extent(1) == 1)
   {
-    auto res = std::transform_reduce(A.begin(), A.end(), 0., std::plus{},
-                                     [](auto v) { return v * v; });
-    P = (1 / res) * xt::transpose(A);
+    T res = 0;
+    for (std::size_t i = 0; i < A.extent(0); ++i)
+      for (std::size_t j = 0; j < A.extent(1); ++j)
+        res += A(i, j) * A(i, j);
+
+    for (std::size_t i = 0; i < A.extent(0); ++i)
+      for (std::size_t j = 0; j < A.extent(1); ++j)
+        P(j, i) = (1 / res) * A(i, j);
   }
   else
   {
     throw std::runtime_error("math::pinv is not implemented for "
-                             + std::to_string(A.shape(0)) + "x"
-                             + std::to_string(A.shape(1)) + " matrices.");
+                             + std::to_string(A.extent(0)) + "x"
+                             + std::to_string(A.extent(1)) + " matrices.");
   }
 }
 

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -11,11 +11,9 @@
 #include <cstdint>
 #include <dolfinx/common/Timer.h>
 #include <numeric>
+#include <span>
 #include <type_traits>
 #include <vector>
-#include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx
 {
@@ -26,7 +24,7 @@ namespace dolfinx
 /// @tparam BITS The number of bits to sort at a time.
 /// @param[in, out] array The array to sort.
 template <typename T, int BITS = 8>
-void radix_sort(const xtl::span<T>& array)
+void radix_sort(const std::span<T>& array)
 {
   static_assert(std::is_integral<T>(), "This function only sorts integers.");
 
@@ -54,8 +52,8 @@ void radix_sort(const xtl::span<T>& array)
 
   std::int32_t mask_offset = 0;
   std::vector<T> buffer(array.size());
-  xtl::span<T> current_perm = array;
-  xtl::span<T> next_perm = buffer;
+  std::span<T> current_perm = array;
+  std::span<T> next_perm = buffer;
   for (int i = 0; i < its; i++)
   {
     // Zero counter array
@@ -96,8 +94,8 @@ void radix_sort(const xtl::span<T>& array)
 /// @param[in] array The array to sort
 /// @param[in] perm FIXME
 template <typename T, int BITS = 16>
-void argsort_radix(const xtl::span<const T>& array,
-                   xtl::span<std::int32_t> perm)
+void argsort_radix(const std::span<const T>& array,
+                   std::span<std::int32_t> perm)
 {
   static_assert(std::is_integral_v<T>, "Integral required.");
 
@@ -126,8 +124,8 @@ void argsort_radix(const xtl::span<const T>& array,
   std::array<std::int32_t, bucket_size + 1> offset;
 
   std::vector<std::int32_t> perm2(perm.size());
-  xtl::span<std::int32_t> current_perm = perm;
-  xtl::span<std::int32_t> next_perm = perm2;
+  std::span<std::int32_t> current_perm = perm;
+  std::span<std::int32_t> next_perm = perm2;
   for (int i = 0; i < its; i++)
   {
     // Zero counter
@@ -175,7 +173,7 @@ void argsort_radix(const xtl::span<const T>& array,
 /// @note This function is suitable for small values of `shape1`. Each
 /// column of `x` is copied into an array that is then sorted.
 template <typename T, int BITS = 16>
-std::vector<std::int32_t> sort_by_perm(const xtl::span<const T>& x,
+std::vector<std::int32_t> sort_by_perm(const std::span<const T>& x,
                                        std::size_t shape1)
 {
   static_assert(std::is_integral_v<T>, "Integral required.");

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -43,8 +43,7 @@ sort_unique(const U& indices, const V& values)
 
   using T = typename std::pair<typename U::value_type, typename V::value_type>;
   std::vector<T> data(indices.size());
-  std::transform(indices.cbegin(), indices.cend(), values.cbegin(),
-                 data.begin(),
+  std::transform(indices.begin(), indices.end(), values.begin(), data.begin(),
                  [](auto& idx, auto& v) -> T {
                    return {idx, v};
                  });

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -9,9 +9,6 @@
 #include <cmath>
 #include <dolfinx/common/math.h>
 #include <dolfinx/mesh/cell_types.h>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xnoalias.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
@@ -47,21 +44,12 @@ CoordinateElement::tabulate_shape(std::size_t nd, std::size_t num_points) const
   return _element->tabulate_shape(nd, num_points);
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 4>
-CoordinateElement::tabulate(int n, const xt::xtensor<double, 2>& X) const
+void CoordinateElement::tabulate(int nd, std::span<const double> X,
+                                 std::array<std::size_t, 2> shape,
+                                 std::span<double> basis) const
 {
   assert(_element);
-  auto [tab, shape] = _element->tabulate(n, X, {X.shape(0), X.shape(1)});
-  return xt::adapt(
-      tab, std::vector<std::size_t>{shape[0], shape[1], shape[2], shape[3]});
-}
-//--------------------------------------------------------------------------------
-void CoordinateElement::tabulate(int n, const xt::xtensor<double, 2>& X,
-                                 xt::xtensor<double, 4>& basis) const
-{
-  assert(_element);
-  _element->tabulate(n, xtl::span(X), std::array{X.shape(0), X.shape(1)},
-                     basis);
+  _element->tabulate(nd, X, shape, basis);
 }
 //--------------------------------------------------------------------------------
 ElementDofLayout CoordinateElement::create_dof_layout() const
@@ -71,97 +59,78 @@ ElementDofLayout CoordinateElement::create_dof_layout() const
                           _element->entity_closure_dofs(), {}, {});
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::push_forward(
-    xt::xtensor<double, 2>& x, const xt::xtensor<double, 2>& cell_geometry,
-    const xt::xtensor<double, 2>& phi)
-{
-  assert(phi.shape(1) == cell_geometry.shape(0));
-
-  // Compute physical coordinates
-  // x = phi * cell_geometry;
-  x.fill(0);
-  math::dot(phi, cell_geometry, x);
-}
-//-----------------------------------------------------------------------------
-std::array<double, 3>
-CoordinateElement::x0(const xt::xtensor<double, 2>& cell_geometry)
-{
-  std::array<double, 3> x0 = {0, 0, 0};
-  for (std::size_t i = 0; i < cell_geometry.shape(1); ++i)
-    x0[i] += cell_geometry(0, i);
-  return x0;
-}
-//-----------------------------------------------------------------------------
-void CoordinateElement::pull_back_affine(xt::xtensor<double, 2>& X,
-                                         const xt::xtensor<double, 2>& K,
-                                         const std::array<double, 3>& x0,
-                                         const xt::xtensor<double, 2>& x)
-{
-  assert(X.shape(0) == x.shape(0));
-  assert(X.shape(1) == K.shape(0));
-  assert(x.shape(1) == K.shape(1));
-
-  // Calculate X for each point
-  X.fill(0.0);
-  for (std::size_t p = 0; p < x.shape(0); ++p)
-    for (std::size_t i = 0; i < K.shape(0); ++i)
-      for (std::size_t j = 0; j < K.shape(1); ++j)
-        X(p, i) += K(i, j) * (x(p, j) - x0[j]);
-}
-//-----------------------------------------------------------------------------
-void CoordinateElement::pull_back_nonaffine(
-    xt::xtensor<double, 2>& X, const xt::xtensor<double, 2>& x,
-    const xt::xtensor<double, 2>& cell_geometry, double tol, int maxit) const
+void CoordinateElement::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
+                                            cmdspan2_t cell_geometry,
+                                            double tol, int maxit) const
 {
   // Number of points
-  std::size_t num_points = x.shape(0);
+  std::size_t num_points = x.extent(0);
   if (num_points == 0)
     return;
 
   const std::size_t tdim = mesh::cell_dim(this->cell_shape());
-  const std::size_t gdim = x.shape(1);
-  const std::size_t num_xnodes = cell_geometry.shape(0);
-  assert(cell_geometry.shape(1) == gdim);
-  assert(X.shape(0) == num_points);
-  assert(X.shape(1) == tdim);
+  const std::size_t gdim = x.extent(1);
+  const std::size_t num_xnodes = cell_geometry.extent(0);
+  assert(cell_geometry.extent(1) == gdim);
+  assert(X.extent(0) == num_points);
+  assert(X.extent(1) == tdim);
 
-  xt::xtensor<double, 2> dphi({tdim, num_xnodes});
-  xt::xtensor<double, 2> Xk({1, tdim});
+  std::vector<double> dphi_b(tdim * num_xnodes);
+  mdspan2_t dphi(dphi_b.data(), tdim, num_xnodes);
+
+  std::vector<double> Xk_b(tdim);
+  mdspan2_t Xk(Xk_b.data(), 1, tdim);
+
   std::array<double, 3> xk = {0, 0, 0};
-  xt::xtensor<double, 1> dX = xt::empty<double>({tdim});
-  xt::xtensor<double, 2> J({gdim, tdim});
-  xt::xtensor<double, 2> K({tdim, gdim});
-  xt::xtensor<double, 4> basis(_element->tabulate_shape(1, 1));
+
+  std::vector<double> dX(tdim);
+
+  std::vector<double> J_b(gdim * tdim);
+  mdspan2_t J(J_b.data(), gdim, tdim);
+
+  std::vector<double> K_b(tdim * gdim);
+  mdspan2_t K(K_b.data(), tdim, gdim);
+
+  namespace stdex = std::experimental;
+  using mdspan4_t = stdex::mdspan<double, stdex::dextents<std::size_t, 4>>;
+
+  const std::array<std::size_t, 4> bsize = _element->tabulate_shape(1, 1);
+  std::vector<double> basis_b(
+      std::reduce(bsize.begin(), bsize.end(), 1, std::multiplies{}));
+  mdspan4_t basis(basis_b.data(), bsize);
+  std::vector<double> phi(basis.extent(2));
+
   for (std::size_t p = 0; p < num_points; ++p)
   {
-    std::fill(Xk.begin(), Xk.end(), 0.0);
+    std::fill(Xk_b.begin(), Xk_b.end(), 0.0);
     int k;
     for (k = 0; k < maxit; ++k)
     {
-      _element->tabulate(1, Xk, {1, tdim}, basis);
+      _element->tabulate(1, Xk_b, {1, tdim}, basis_b);
 
       // x = cell_geometry * phi
-      auto phi = xt::view(basis, 0, 0, xt::all(), 0);
       std::fill(xk.begin(), xk.end(), 0.0);
-      for (std::size_t i = 0; i < cell_geometry.shape(0); ++i)
-        for (std::size_t j = 0; j < cell_geometry.shape(1); ++j)
-          xk[j] += cell_geometry(i, j) * phi[i];
+      for (std::size_t i = 0; i < cell_geometry.extent(0); ++i)
+        for (std::size_t j = 0; j < cell_geometry.extent(1); ++j)
+          xk[j] += cell_geometry(i, j) * basis(0, 0, i, 0);
 
       // Compute Jacobian, its inverse and determinant
-      std::fill(J.begin(), J.end(), 0.0);
-      dphi = xt::view(basis, xt::range(1, tdim + 1), 0, xt::all(), 0);
+      std::fill(J_b.begin(), J_b.end(), 0.0);
+      for (std::size_t i = 0; i < tdim; ++i)
+        for (std::size_t j = 0; j < basis.extent(2); ++j)
+          dphi(i, j) = basis(i + 1, 0, j, 0);
+
       compute_jacobian(dphi, cell_geometry, J);
       compute_jacobian_inverse(J, K);
 
       // Compute dX = K * (x_p - x_k)
       std::fill(dX.begin(), dX.end(), 0);
-      auto x_p = xt::row(x, p);
-      for (std::size_t i = 0; i < K.shape(0); ++i)
-        for (std::size_t j = 0; j < K.shape(1); ++j)
-          dX[i] += K(i, j) * (x_p[j] - xk[j]);
+      for (std::size_t i = 0; i < K.extent(0); ++i)
+        for (std::size_t j = 0; j < K.extent(1); ++j)
+          dX[i] += K(i, j) * (x(p, j) - xk[j]);
 
       // Compute Xk += dX
-      std::transform(dX.cbegin(), dX.cend(), Xk.cbegin(), Xk.begin(),
+      std::transform(dX.begin(), dX.end(), Xk_b.begin(), Xk_b.begin(),
                      [](double a, double b) { return a + b; });
 
       // Compute norm(dX)
@@ -173,8 +142,9 @@ void CoordinateElement::pull_back_nonaffine(
         break;
       }
     }
-    std::copy(Xk.cbegin(), std::next(Xk.cbegin(), tdim),
-              std::next(X.begin(), p * tdim));
+
+    std::copy(Xk_b.cbegin(), std::next(Xk_b.cbegin(), tdim),
+              X.data_handle() + p * tdim);
     if (k == maxit)
     {
       throw std::runtime_error(
@@ -183,14 +153,14 @@ void CoordinateElement::pull_back_nonaffine(
   }
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::permute_dofs(const xtl::span<std::int32_t>& dofs,
+void CoordinateElement::permute_dofs(const std::span<std::int32_t>& dofs,
                                      std::uint32_t cell_perm) const
 {
   assert(_element);
   _element->permute_dofs(dofs, cell_perm);
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::unpermute_dofs(const xtl::span<std::int32_t>& dofs,
+void CoordinateElement::unpermute_dofs(const std::span<std::int32_t>& dofs,
                                        std::uint32_t cell_perm) const
 {
   assert(_element);

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -7,13 +7,14 @@
 #pragma once
 
 #include "ElementDofLayout.h"
+#include <array>
 #include <basix/element-families.h>
+#include <basix/mdspan.hpp>
 #include <cstdint>
 #include <dolfinx/common/math.h>
 #include <dolfinx/mesh/cell_types.h>
 #include <memory>
-#include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
+#include <span>
 
 namespace basix
 {
@@ -77,22 +78,14 @@ public:
   /// @param[in] nd The order of derivatives, up to and including, to
   /// compute. Use 0 for the basis functions only.
   /// @param[in] X The points at which to compute the basis functions.
-  /// The shape of x is (number of points, geometric dimension).
-  /// @return The basis functions (and derivatives). The shape is
-  /// (derivative, number point, number of basis fn, value size).
-  xt::xtensor<double, 4> tabulate(int nd,
-                                  const xt::xtensor<double, 2>& X) const;
-
-  /// Evaluate basis values and derivatives at set of points.
-  /// @param[in] nd The order of derivatives, up to and including, to
-  /// compute. Use 0 for the basis functions only.
-  /// @param[in] X The points at which to compute the basis functions.
   /// The shape of X is (number of points, geometric dimension).
+  /// @param[in] shape The shape of `X`.
   /// @param[out] basis The array to fill with the basis function
   /// values. The shape can be computed using
   /// `FiniteElement::tabulate_shape`
-  void tabulate(int nd, const xt::xtensor<double, 2>& X,
-                xt::xtensor<double, 4>& basis) const;
+  void tabulate(int nd, std::span<const double> X,
+                std::array<std::size_t, 2> shape,
+                std::span<double> basis) const;
 
   /// Compute Jacobian for a cell with given geometry using the
   /// basis functions and first order derivatives.
@@ -114,8 +107,8 @@ public:
   template <typename U, typename V>
   static void compute_jacobian_inverse(const U& J, V&& K)
   {
-    const int gdim = J.shape(1);
-    const int tdim = K.shape(1);
+    const int gdim = J.extent(1);
+    const int tdim = K.extent(1);
     if (gdim == tdim)
       math::inv(J, K);
     else
@@ -124,17 +117,32 @@ public:
 
   /// Compute the determinant of the Jacobian
   /// @param[in] J Jacobian (shape=(gdim, tdim))
+  /// @param[in] w Working memory, required when gdim != tdim. Size
+  /// must be at least 2 * gdim * tdim.
   /// @return Determinant of `J`
   template <typename U>
-  static double compute_jacobian_determinant(const U& J)
+  static double
+  compute_jacobian_determinant(const U& J, std::span<typename U::value_type> w)
   {
-    if (J.shape(0) == J.shape(1))
+    static_assert(U::rank() == 2, "Must be rank 2");
+    if (J.extent(0) == J.extent(1))
       return math::det(J);
     else
     {
-      using T = typename U::value_type;
-      auto B = xt::transpose(J);
-      xt::xtensor<T, 2> BA = xt::zeros<T>({B.shape(0), J.shape(1)});
+      // TODO: pass buffers for B and BA
+      assert(w.size() >= 2 * J.extent(0) * J.extent(1));
+
+      using T = typename U::element_type;
+      namespace stdex = std::experimental;
+      using mdspan2_t = stdex::mdspan<T, stdex::dextents<std::size_t, 2>>;
+      mdspan2_t B(w.data(), J.extent(1), J.extent(0));
+      mdspan2_t BA(w.data() + J.extent(0) * J.extent(1), B.extent(0),
+                   J.extent(1));
+
+      for (std::size_t i = 0; i < B.extent(0); ++i)
+        for (std::size_t j = 0; j < B.extent(1); ++j)
+          B(i, j) = J(j, i);
+
       math::dot(B, J, BA);
       return std::sqrt(math::det(BA));
     }
@@ -143,22 +151,22 @@ public:
   /// Compute and return the dof layout
   ElementDofLayout create_dof_layout() const;
 
-  /// Compute physical coordinates x for points X  in the reference
-  /// configuration
-  /// @param[in,out] x The physical coordinates of the reference points X
-  /// @param[in] cell_geometry The cell node coordinates (physical)
-  /// @param[in] phi Tabulated basis functions at reference points X
-  static void push_forward(xt::xtensor<double, 2>& x,
-                           const xt::xtensor<double, 2>& cell_geometry,
-                           const xt::xtensor<double, 2>& phi);
+  /// @brief Compute physical coordinates x for points X  in the
+  /// reference configuration
+  /// @param[in,out] x The physical coordinates of the reference points
+  /// X (rank 2)
+  /// @param[in] cell_geometry The cell node physical coordinates (rank 2)
+  /// @param[in] phi Tabulated basis functions at reference points X (rank 2)
+  template <typename U, typename V, typename W>
+  static void push_forward(U&& x, const V& cell_geometry, const W& phi)
+  {
+    for (std::size_t i = 0; i < x.extent(0); ++i)
+      for (std::size_t j = 0; j < x.extent(1); ++j)
+        x(i, j) = 0;
 
-  /// Compute the physical coordinate of the reference point X=(0 , 0,
-  /// 0)
-  /// @param[in] cell_geometry The cell nodes coordinates (shape=(num
-  /// geometry nodes, gdim))
-  /// @return Physical coordinate of the X=(0, 0, 0)
-  /// @note Assumes that x0 is given by cell_geometry(0, i)
-  static std::array<double, 3> x0(const xt::xtensor<double, 2>& cell_geometry);
+    // Compute x = phi * cell_geometry;
+    math::dot(phi, cell_geometry, x);
+  }
 
   /// Compute reference coordinates X for physical coordinates x for an
   /// affine map. For the affine case, `x = J X + x0`, and this function
@@ -170,33 +178,53 @@ public:
   /// @param[in] x0 The physical coordinate of reference coordinate X0=(0, 0,
   /// 0).
   /// @param[in] x The physical coordinates (shape=(num_points, gdim))
-  static void pull_back_affine(xt::xtensor<double, 2>& X,
-                               const xt::xtensor<double, 2>& K,
-                               const std::array<double, 3>& x0,
-                               const xt::xtensor<double, 2>& x);
+  template <typename U, typename V, typename W>
+  static void pull_back_affine(U&& X, const V& K,
+                               const std::array<double, 3>& x0, const W& x)
+  {
+    assert(X.extent(0) == x.extent(0));
+    assert(X.extent(1) == K.extent(0));
+    assert(x.extent(1) == K.extent(1));
+    for (std::size_t i = 0; i < X.extent(0); ++i)
+      for (std::size_t j = 0; j < X.extent(1); ++j)
+        X(i, j) = 0;
+
+    // Calculate X for each point
+    for (std::size_t p = 0; p < x.extent(0); ++p)
+      for (std::size_t i = 0; i < K.extent(0); ++i)
+        for (std::size_t j = 0; j < K.extent(1); ++j)
+          X(p, i) += K(i, j) * (x(p, j) - x0[j]);
+  }
+
+  /// mdspan typedef
+  using mdspan2_t
+      = std::experimental::mdspan<double,
+                                  std::experimental::dextents<std::size_t, 2>>;
+  /// mdspan typedef
+  using cmdspan2_t
+      = std::experimental::mdspan<const double,
+                                  std::experimental::dextents<std::size_t, 2>>;
 
   /// Compute reference coordinates X for physical coordinates x for a
   /// non-affine map.
-  /// @param [in,out] X The reference coordinates to compute (shape=(num_points,
-  /// tdim))
-  /// @param [in] x The physical coordinates (shape=(num_points, gdim))
+  /// @param [in,out] X The reference coordinates to compute
+  /// (shape=`(num_points, tdim)`)
+  /// @param [in] x The physical coordinates (shape=`(num_points, gdim)`)
   /// @param [in] cell_geometry The cell nodes coordinates (shape=(num
   /// geometry nodes, gdim))
   /// @param [in] tol Tolerance for termination of Newton method.
   /// @param [in] maxit Maximum number of Newton iterations
-  /// @note If convergence is not achieved within maxit, the function throws a
-  /// run-time error.
-  void pull_back_nonaffine(xt::xtensor<double, 2>& X,
-                           const xt::xtensor<double, 2>& x,
-                           const xt::xtensor<double, 2>& cell_geometry,
+  /// @note If convergence is not achieved within maxit, the function
+  /// throws a runtime error.
+  void pull_back_nonaffine(mdspan2_t X, cmdspan2_t x, cmdspan2_t cell_geometry,
                            double tol = 1.0e-8, int maxit = 10) const;
 
   /// Permutes a list of DOF numbers on a cell
-  void permute_dofs(const xtl::span<std::int32_t>& dofs,
+  void permute_dofs(const std::span<std::int32_t>& dofs,
                     std::uint32_t cell_perm) const;
 
   /// Reverses a DOF permutation
-  void unpermute_dofs(const xtl::span<std::int32_t>& dofs,
+  void unpermute_dofs(const std::span<std::int32_t>& dofs,
                       std::uint32_t cell_perm) const;
 
   /// Indicates whether the geometry DOF numbers on each cell need

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -13,12 +13,12 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <span>
 #include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
 #include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::fem
 {
@@ -46,7 +46,7 @@ namespace dolfinx::fem
 /// with V.
 std::vector<std::int32_t>
 locate_dofs_topological(const FunctionSpace& V, int dim,
-                        const xtl::span<const std::int32_t>& entities,
+                        const std::span<const std::int32_t>& entities,
                         bool remote = true);
 
 /// Find degrees-of-freedom which belong to the provided mesh entities
@@ -74,7 +74,7 @@ locate_dofs_topological(const FunctionSpace& V, int dim,
 /// V[1]. The returned dofs are 'unrolled', i.e. block size = 1.
 std::array<std::vector<std::int32_t>, 2> locate_dofs_topological(
     const std::array<std::reference_wrapper<const FunctionSpace>, 2>& V,
-    int dim, const xtl::span<const std::int32_t>& entities, bool remote = true);
+    int dim, const std::span<const std::int32_t>& entities, bool remote = true);
 
 /// Finds degrees of freedom whose geometric coordinate is true for the
 /// provided marking function.
@@ -321,7 +321,7 @@ public:
   /// @return Sorted array of dof indices (unrolled) and index to the
   /// first entry in the dof index array that is not owned. Entries
   /// `dofs[:pos]` are owned and entries `dofs[pos:]` are ghosts.
-  std::pair<xtl::span<const std::int32_t>, std::int32_t> dof_indices() const
+  std::pair<std::span<const std::int32_t>, std::int32_t> dof_indices() const
   {
     return {_dofs0, _owned_indices0};
   }
@@ -337,14 +337,14 @@ public:
   /// of the array @p x should be equal to the number of dofs owned by
   /// this rank.
   /// @param[in] scale The scaling value to apply
-  void set(xtl::span<T> x, double scale = 1.0) const
+  void set(std::span<T> x, double scale = 1.0) const
   {
     if (std::holds_alternative<std::shared_ptr<const Function<T>>>(_g))
     {
       auto g = std::get<std::shared_ptr<const Function<T>>>(_g);
       assert(g);
-      xtl::span<const T> values = g->x()->array();
-      auto dofs1_g = _dofs1_g.empty() ? xtl::span(_dofs0) : xtl::span(_dofs1_g);
+      std::span<const T> values = g->x()->array();
+      auto dofs1_g = _dofs1_g.empty() ? std::span(_dofs0) : std::span(_dofs1_g);
       std::int32_t x_size = x.size();
       for (std::size_t i = 0; i < _dofs0.size(); ++i)
       {
@@ -374,16 +374,16 @@ public:
   /// @param[in] x The array in which to set `scale * (x0 - x_bc)`
   /// @param[in] x0 The array used in compute the value to set
   /// @param[in] scale The scaling value to apply
-  void set(xtl::span<T> x, const xtl::span<const T>& x0,
+  void set(std::span<T> x, const std::span<const T>& x0,
            double scale = 1.0) const
   {
     if (std::holds_alternative<std::shared_ptr<const Function<T>>>(_g))
     {
       auto g = std::get<std::shared_ptr<const Function<T>>>(_g);
       assert(g);
-      xtl::span<const T> values = g->x()->array();
+      std::span<const T> values = g->x()->array();
       assert(x.size() <= x0.size());
-      auto dofs1_g = _dofs1_g.empty() ? xtl::span(_dofs0) : xtl::span(_dofs1_g);
+      auto dofs1_g = _dofs1_g.empty() ? std::span(_dofs0) : std::span(_dofs1_g);
       std::int32_t x_size = x.size();
       for (std::size_t i = 0; i < _dofs0.size(); ++i)
       {
@@ -416,14 +416,14 @@ public:
   /// @param[out] values The array in which to set the dof values.
   /// The array must be at least as long as the array associated with V1
   /// (the space of the function that provides the dof values)
-  void dof_values(xtl::span<T> values) const
+  void dof_values(std::span<T> values) const
   {
     if (std::holds_alternative<std::shared_ptr<const Function<T>>>(_g))
     {
       auto g = std::get<std::shared_ptr<const Function<T>>>(_g);
       assert(g);
-      xtl::span<const T> g_values = g->x()->array();
-      auto dofs1_g = _dofs1_g.empty() ? xtl::span(_dofs0) : xtl::span(_dofs1_g);
+      std::span<const T> g_values = g->x()->array();
+      auto dofs1_g = _dofs1_g.empty() ? std::span(_dofs0) : std::span(_dofs1_g);
       for (std::size_t i = 0; i < dofs1_g.size(); ++i)
         values[_dofs0[i]] = g_values[dofs1_g[i]];
     }
@@ -444,7 +444,7 @@ public:
   /// V0 had a boundary condition applied, i.e. dofs which are fixed by
   /// a boundary condition. Other entries in @p markers are left
   /// unchanged.
-  void mark_dofs(const xtl::span<std::int8_t>& markers) const
+  void mark_dofs(const std::span<std::int8_t>& markers) const
   {
     for (std::size_t i = 0; i < _dofs0.size(); ++i)
     {

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -43,7 +43,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
 
   // Build set of dofs that are in the new dofmap (un-blocked)
   std::vector<std::int32_t> dofs_view = dofmap_view.list().array();
-  dolfinx::radix_sort(xtl::span(dofs_view));
+  dolfinx::radix_sort(std::span(dofs_view));
   dofs_view.erase(std::unique(dofs_view.begin(), dofs_view.end()),
                   dofs_view.end());
 
@@ -61,7 +61,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   std::vector<std::int32_t> ghost_new_to_old;
   if (bs_view == 1)
   {
-    xtl::span<std::int32_t> indices(dofs_view.data(),
+    std::span<std::int32_t> indices(dofs_view.data(),
                                     std::distance(dofs_view.begin(), it));
     auto [_index_map, gmap] = dofmap_view.index_map->create_submap(indices);
     index_map = std::make_shared<common::IndexMap>(std::move(_index_map));
@@ -263,8 +263,8 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
   const int bs = dofmap_new.bs();
   for (int c = 0; c < cells->num_nodes(); ++c)
   {
-    xtl::span<const std::int32_t> cell_dofs_view = this->cell_dofs(c);
-    xtl::span<const std::int32_t> cell_dofs = dofmap_new.cell_dofs(c);
+    std::span<const std::int32_t> cell_dofs_view = this->cell_dofs(c);
+    std::span<const std::int32_t> cell_dofs = dofmap_new.cell_dofs(c);
     for (std::size_t i = 0; i < cell_dofs.size(); ++i)
     {
       for (int k = 0; k < bs; ++k)

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -17,9 +17,9 @@
 #include <functional>
 #include <memory>
 #include <mpi.h>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::common
 {
@@ -119,7 +119,7 @@ public:
   /// @param[in] cell The cell index
   /// @return Local-global dof map for the cell (using process-local
   /// indices)
-  xtl::span<const std::int32_t> cell_dofs(int cell) const
+  std::span<const std::int32_t> cell_dofs(int cell) const
   {
     return _dofmap.links(cell);
   }

--- a/cpp/dolfinx/fem/ElementDofLayout.cpp
+++ b/cpp/dolfinx/fem/ElementDofLayout.cpp
@@ -97,7 +97,7 @@ ElementDofLayout::entity_closure_dofs_all() const
 int ElementDofLayout::num_sub_dofmaps() const { return _sub_dofmaps.size(); }
 //-----------------------------------------------------------------------------
 const ElementDofLayout&
-ElementDofLayout::sub_layout(const xtl::span<const int>& component) const
+ElementDofLayout::sub_layout(const std::span<const int>& component) const
 {
   if (component.empty())
     throw std::runtime_error("No sub dofmap specified");
@@ -110,7 +110,7 @@ ElementDofLayout::sub_layout(const xtl::span<const int>& component) const
 }
 //-----------------------------------------------------------------------------
 std::vector<int>
-ElementDofLayout::sub_view(const xtl::span<const int>& component) const
+ElementDofLayout::sub_view(const std::span<const int>& component) const
 {
   // Fill up a list of parent dofs, from which subdofmap will select
   std::vector<int> dof_list(_num_dofs * _block_size);

--- a/cpp/dolfinx/fem/ElementDofLayout.h
+++ b/cpp/dolfinx/fem/ElementDofLayout.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <array>
+#include <span>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::mesh
 {
@@ -111,12 +111,12 @@ public:
 
   /// Get sub-dofmap given by list of components, one for each level
   const ElementDofLayout&
-  sub_layout(const xtl::span<const int>& component) const;
+  sub_layout(const std::span<const int>& component) const;
 
   /// Get view for a sub-layout, defined by the component list (as for
   /// sub_layour()), into this dofmap. I.e., the dofs in this dofmap
   /// that are the sub-dofs.
-  std::vector<int> sub_view(const xtl::span<const int>& component) const;
+  std::vector<int> sub_view(const std::span<const int>& component) const;
 
   /// Block size
   int block_size() const;

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -7,13 +7,13 @@
 #pragma once
 
 #include "Function.h"
+#include <array>
 #include <dolfinx/common/utils.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <functional>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::fem
 {
@@ -52,15 +52,16 @@ public:
   /// @param[in] coefficients Coefficients in the Expression
   /// @param[in] constants Constants in the Expression
   /// @param[in] mesh
-  /// @param[in] X points on reference cell, number of points rows and
-  /// tdim cols
+  /// @param[in] X points on reference cell, shape=(number of points,
+  /// tdim) and storage is row-major.
+  /// @param[in] Xshape Shape of `X`.
   /// @param[in] fn function for tabulating expression
   /// @param[in] value_shape shape of expression evaluated at single point
   /// @param[in] argument_function_space Function space for Argument
   Expression(
       const std::vector<std::shared_ptr<const Function<T>>>& coefficients,
       const std::vector<std::shared_ptr<const Constant<T>>>& constants,
-      const xt::xtensor<double, 2>& X,
+      std::span<const double> X, std::array<std::size_t, 2> Xshape,
       const std::function<void(T*, const T*, const T*,
                                const scalar_value_type_t*, const int*,
                                const uint8_t*)>
@@ -70,7 +71,8 @@ public:
       const std::shared_ptr<const FunctionSpace> argument_function_space
       = nullptr)
       : _coefficients(coefficients), _constants(constants), _mesh(mesh),
-        _x_ref(X), _fn(fn), _value_shape(value_shape),
+        _x_ref(std::vector<double>(X.begin(), X.end()), Xshape), _fn(fn),
+        _value_shape(value_shape),
         _argument_function_space(argument_function_space)
   {
     // Extract mesh from argument's function space
@@ -135,7 +137,7 @@ public:
   /// is responsible for correct sizing which should be (num_cells,
   /// num_points * value_size * num_all_argument_dofs columns).
   template <typename U>
-  void eval(const xtl::span<const std::int32_t>& cells, U& values) const
+  void eval(const std::span<const std::int32_t>& cells, U& values) const
   {
     // Extract data from Expression
     assert(_mesh);
@@ -149,18 +151,18 @@ public:
     const graph::AdjacencyList<std::int32_t>& x_dofmap
         = _mesh->geometry().dofmap();
     const std::size_t num_dofs_g = _mesh->geometry().cmap().dim();
-    xtl::span<const double> x_g = _mesh->geometry().x();
+    std::span<const double> x_g = _mesh->geometry().x();
 
     // Create data structures used in evaluation
     std::vector<scalar_value_type_t> coordinate_dofs(3 * num_dofs_g);
 
     int num_argument_dofs = 1;
-    xtl::span<const std::uint32_t> cell_info;
-    std::function<void(const xtl::span<T>&,
-                       const xtl::span<const std::uint32_t>&, std::int32_t,
+    std::span<const std::uint32_t> cell_info;
+    std::function<void(const std::span<T>&,
+                       const std::span<const std::uint32_t>&, std::int32_t,
                        int)>
         dof_transform_to_transpose
-        = [](const xtl::span<T>&, const xtl::span<const std::uint32_t>&,
+        = [](const std::span<T>&, const std::span<const std::uint32_t>&,
              std::int32_t, int)
     {
       // Do nothing
@@ -176,16 +178,16 @@ public:
       if (element->needs_dof_transformations())
       {
         _mesh->topology_mutable().create_entity_permutations();
-        cell_info = xtl::span(_mesh->topology().get_cell_permutation_info());
+        cell_info = std::span(_mesh->topology().get_cell_permutation_info());
         dof_transform_to_transpose
             = element
                   ->template get_dof_transformation_to_transpose_function<T>();
       }
     }
 
-    const int size0 = _x_ref.shape(0) * value_size();
+    const int size0 = _x_ref.second[0] * value_size();
     std::vector<T> values_local(size0 * num_argument_dofs, 0);
-    const xtl::span<T> _values_local(values_local);
+    const std::span<T> _values_local(values_local);
 
     // Iterate over cells and 'assemble' into values
     for (std::size_t c = 0; c < cells.size(); ++c)
@@ -238,7 +240,10 @@ public:
 
   /// @brief Evaluation points on the reference cell
   /// @return Evaluation points
-  const xt::xtensor<double, 2>& X() const { return _x_ref; }
+  std::pair<std::vector<double>, std::array<std::size_t, 2>> X() const
+  {
+    return _x_ref;
+  }
 
   /// Scalar type (T)
   using scalar_type = T;
@@ -265,6 +270,6 @@ private:
   std::vector<int> _value_shape;
 
   // Evaluation points on reference cell. Synonymous with X in public interface.
-  xt::xtensor<double, 2> _x_ref;
+  std::pair<std::vector<double>, std::array<std::size_t, 2>> _x_ref;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -16,7 +16,6 @@
 #include <ufcx.h>
 #include <utility>
 #include <vector>
-#include <xtensor/xadapt.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
@@ -340,29 +339,27 @@ int FiniteElement::reference_value_size() const
 //-----------------------------------------------------------------------------
 int FiniteElement::block_size() const noexcept { return _bs; }
 //-----------------------------------------------------------------------------
-xtl::span<const std::size_t> FiniteElement::value_shape() const noexcept
+std::span<const std::size_t> FiniteElement::value_shape() const noexcept
 {
   return _value_shape;
 }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family() const noexcept { return _family; }
 //-----------------------------------------------------------------------------
-void FiniteElement::tabulate(xt::xtensor<double, 4>& reference_values,
-                             const xt::xtensor<double, 2>& X, int order) const
+void FiniteElement::tabulate(std::span<double> values,
+                             std::span<const double> X,
+                             std::array<std::size_t, 2> shape, int order) const
 {
   assert(_element);
-  _element->tabulate(
-      order, xtl::span(X), std::array{X.shape(0), X.shape(1)},
-      xtl::span<double>(reference_values.data(), reference_values.size()));
+  _element->tabulate(order, X, shape, values);
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 4> FiniteElement::tabulate(const xt::xtensor<double, 2>& X,
-                                               int order) const
+std::pair<std::vector<double>, std::array<std::size_t, 4>>
+FiniteElement::tabulate(std::span<const double> X,
+                        std::array<std::size_t, 2> shape, int order) const
 {
   assert(_element);
-  auto [tab, shape] = _element->tabulate(order, X, {X.shape(0), X.shape(1)});
-  return xt::adapt(
-      tab, std::vector<std::size_t>{shape[0], shape[1], shape[2], shape[3]});
+  return _element->tabulate(order, X, shape);
 }
 //-----------------------------------------------------------------------------
 int FiniteElement::num_sub_elements() const noexcept
@@ -426,7 +423,8 @@ bool FiniteElement::interpolation_ident() const noexcept
   return _element->interpolation_is_identity();
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2> FiniteElement::interpolation_points() const
+std::pair<std::vector<double>, std::array<std::size_t, 2>>
+FiniteElement::interpolation_points() const
 {
   if (!_element)
   {
@@ -435,11 +433,11 @@ xt::xtensor<double, 2> FiniteElement::interpolation_points() const
         "this is a mixed element?");
   }
 
-  auto& [x, shape] = _element->points();
-  return xt::adapt(x, std::vector<std::size_t>{shape[0], shape[1]});
+  return _element->points();
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2> FiniteElement::interpolation_operator() const
+std::pair<std::vector<double>, std::array<std::size_t, 2>>
+FiniteElement::interpolation_operator() const
 {
   if (!_element)
   {
@@ -447,11 +445,10 @@ xt::xtensor<double, 2> FiniteElement::interpolation_operator() const
                              "Cannot interpolate mixed elements directly.");
   }
 
-  auto& [im, shape] = _element->interpolation_matrix();
-  return xt::adapt(im, std::vector<std::size_t>{shape[0], shape[1]});
+  return _element->interpolation_matrix();
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2>
+std::pair<std::vector<double>, std::array<std::size_t, 2>>
 FiniteElement::create_interpolation_operator(const FiniteElement& from) const
 {
   assert(_element);
@@ -466,28 +463,26 @@ FiniteElement::create_interpolation_operator(const FiniteElement& from) const
   {
     // If one of the elements has bs=1, Basix can figure out the size
     // of the matrix
-    auto [data, shape]
-        = basix::compute_interpolation_operator(*from._element, *_element);
-    return xt::adapt(data, std::vector<std::size_t>{shape[0], shape[1]});
+    return basix::compute_interpolation_operator(*from._element, *_element);
   }
   else if (_bs > 1 and from._bs == _bs)
   {
     // If bs != 1 for at least one element, then bs0 == bs1 for this
     // case
-    auto [data, dshape]
+    const auto [data, dshape]
         = basix::compute_interpolation_operator(*from._element, *_element);
-    auto i_m = xt::adapt(data, std::vector<std::size_t>{dshape[0], dshape[1]});
-    std::array<std::size_t, 2> shape = {i_m.shape(0) * _bs, i_m.shape(1) * _bs};
-    xt::xtensor<double, 2> out = xt::zeros<double>(shape);
+    std::array<std::size_t, 2> shape = {dshape[0] * _bs, dshape[1] * _bs};
+    std::vector<double> out(shape[0] * shape[1]);
 
     // NOTE: Alternatively this operation could be implemented during
     // matvec with the original matrix
-    for (std::size_t i = 0; i < i_m.shape(0); ++i)
-      for (std::size_t j = 0; j < i_m.shape(1); ++j)
+    for (std::size_t i = 0; i < dshape[0]; ++i)
+      for (std::size_t j = 0; j < dshape[1]; ++j)
         for (int k = 0; k < _bs; ++k)
-          out(i * _bs + k, j * _bs + k) = i_m(i, j);
+          out[shape[1] * (i * _bs + k) + (j * _bs + k)]
+              = data[dshape[1] * i + j];
 
-    return out;
+    return {std::move(out), shape};
   }
   else
   {
@@ -506,19 +501,19 @@ bool FiniteElement::needs_dof_permutations() const noexcept
   return _needs_dof_permutations;
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::permute_dofs(const xtl::span<std::int32_t>& doflist,
+void FiniteElement::permute_dofs(const std::span<std::int32_t>& doflist,
                                  std::uint32_t cell_permutation) const
 {
   _element->permute_dofs(doflist, cell_permutation);
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::unpermute_dofs(const xtl::span<std::int32_t>& doflist,
+void FiniteElement::unpermute_dofs(const std::span<std::int32_t>& doflist,
                                    std::uint32_t cell_permutation) const
 {
   _element->unpermute_dofs(doflist, cell_permutation);
 }
 //-----------------------------------------------------------------------------
-std::function<void(const xtl::span<std::int32_t>&, std::uint32_t)>
+std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
 FiniteElement::get_dof_permutation_function(bool inverse,
                                             bool scalar_element) const
 {
@@ -528,13 +523,13 @@ FiniteElement::get_dof_permutation_function(bool inverse,
     {
       // If this element shouldn't be permuted, return a function that
       // does nothing
-      return [](const xtl::span<std::int32_t>&, std::uint32_t) {};
+      return [](const std::span<std::int32_t>&, std::uint32_t) {};
     }
     else
     {
       // If this element shouldn't be permuted but needs
       // transformations, return a function that throws an error
-      return [](const xtl::span<std::int32_t>&, std::uint32_t)
+      return [](const std::span<std::int32_t>&, std::uint32_t)
       {
         throw std::runtime_error(
             "Permutations should not be applied for this element.");
@@ -548,7 +543,7 @@ FiniteElement::get_dof_permutation_function(bool inverse,
     {
       // Mixed element
       std::vector<
-          std::function<void(const xtl::span<std::int32_t>&, std::uint32_t)>>
+          std::function<void(const std::span<std::int32_t>&, std::uint32_t)>>
           sub_element_functions;
       std::vector<int> dims;
       for (std::size_t i = 0; i < _sub_elements.size(); ++i)
@@ -559,7 +554,7 @@ FiniteElement::get_dof_permutation_function(bool inverse,
       }
 
       return
-          [dims, sub_element_functions](const xtl::span<std::int32_t>& doflist,
+          [dims, sub_element_functions](const std::span<std::int32_t>& doflist,
                                         std::uint32_t cell_permutation)
       {
         std::size_t start = 0;
@@ -574,14 +569,14 @@ FiniteElement::get_dof_permutation_function(bool inverse,
     else if (!scalar_element)
     {
       // Vector element
-      std::function<void(const xtl::span<std::int32_t>&, std::uint32_t)>
+      std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
           sub_element_function
           = _sub_elements[0]->get_dof_permutation_function(inverse);
       int dim = _sub_elements[0]->space_dimension();
       int bs = _bs;
       return
           [sub_element_function, bs, subdofs = std::vector<std::int32_t>(dim)](
-              const xtl::span<std::int32_t>& doflist,
+              const std::span<std::int32_t>& doflist,
               std::uint32_t cell_permutation) mutable
       {
         for (int k = 0; k < bs; ++k)
@@ -598,13 +593,13 @@ FiniteElement::get_dof_permutation_function(bool inverse,
 
   if (inverse)
   {
-    return [this](const xtl::span<std::int32_t>& doflist,
+    return [this](const std::span<std::int32_t>& doflist,
                   std::uint32_t cell_permutation)
     { unpermute_dofs(doflist, cell_permutation); };
   }
   else
   {
-    return [this](const xtl::span<std::int32_t>& doflist,
+    return [this](const std::span<std::int32_t>& doflist,
                   std::uint32_t cell_permutation)
     { permute_dofs(doflist, cell_permutation); };
   }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -378,7 +378,7 @@ private:
   template <int num_cells>
   static std::array<std::array<std::int32_t, 2>, num_cells>
   get_cell_local_facet_pairs(
-      std::int32_t f, const xtl::span<const std::int32_t>& cells,
+      std::int32_t f, const std::span<const std::int32_t>& cells,
       const dolfinx::graph::AdjacencyList<std::int32_t>& c_to_f)
   {
     // Loop over cells sharing facet

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -12,7 +12,6 @@
 #include <map>
 #include <memory>
 #include <vector>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx::mesh
 {

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -18,6 +18,7 @@
 #include <dolfinx/mesh/Topology.h>
 #include <functional>
 #include <iterator>
+#include <span>
 #include <vector>
 
 namespace dolfinx::fem::impl
@@ -30,33 +31,33 @@ namespace dolfinx::fem::impl
 /// are applied. Matrix is not finalised.
 template <typename T, typename U>
 void assemble_matrix(
-    U mat_set_values, const Form<T>& a, const xtl::span<const T>& constants,
+    U mat_set_values, const Form<T>& a, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients,
-    const xtl::span<const std::int8_t>& bc0,
-    const xtl::span<const std::int8_t>& bc1);
+                   std::pair<std::span<const T>, int>>& coefficients,
+    const std::span<const std::int8_t>& bc0,
+    const std::span<const std::int8_t>& bc1);
 
 /// Execute kernel over cells and accumulate result in matrix
 template <typename T, typename U>
 void assemble_cells(
     U mat_set, const mesh::Geometry& geometry,
-    const xtl::span<const std::int32_t>& cells,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::span<const std::int32_t>& cells,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
     const graph::AdjacencyList<std::int32_t>& dofmap0, int bs0,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
-    const xtl::span<const std::int8_t>& bc0,
-    const xtl::span<const std::int8_t>& bc1,
+    const std::span<const std::int8_t>& bc0,
+    const std::span<const std::int8_t>& bc1,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& kernel,
-    const xtl::span<const T>& coeffs, int cstride,
-    const xtl::span<const T>& constants,
-    const xtl::span<const std::uint32_t>& cell_info)
+    const std::span<const T>& coeffs, int cstride,
+    const std::span<const T>& constants,
+    const std::span<const std::uint32_t>& cell_info)
 {
   if (cells.empty())
     return;
@@ -64,7 +65,7 @@ void assemble_cells(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmap().dim();
-  xtl::span<const double> x_g = geometry.x();
+  std::span<const double> x_g = geometry.x();
 
   // Iterate over active cells
   const int num_dofs0 = dofmap0.links(0).size();
@@ -72,7 +73,7 @@ void assemble_cells(
   const int ndim0 = bs0 * num_dofs0;
   const int ndim1 = bs1 * num_dofs1;
   std::vector<T> Ae(ndim0 * ndim1);
-  const xtl::span<T> _Ae(Ae);
+  const std::span<T> _Ae(Ae);
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
 
   // Iterate over active cells
@@ -140,23 +141,23 @@ void assemble_cells(
 template <typename T, typename U>
 void assemble_exterior_facets(
     U mat_set, const mesh::Mesh& mesh,
-    const xtl::span<const std::int32_t>& facets,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::span<const std::int32_t>& facets,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
     const graph::AdjacencyList<std::int32_t>& dofmap0, int bs0,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
-    const xtl::span<const std::int8_t>& bc0,
-    const xtl::span<const std::int8_t>& bc1,
+    const std::span<const std::int8_t>& bc0,
+    const std::span<const std::int8_t>& bc1,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& kernel,
-    const xtl::span<const T>& coeffs, int cstride,
-    const xtl::span<const T>& constants,
-    const xtl::span<const std::uint32_t>& cell_info)
+    const std::span<const T>& coeffs, int cstride,
+    const std::span<const T>& constants,
+    const std::span<const std::uint32_t>& cell_info)
 {
   if (facets.empty())
     return;
@@ -164,7 +165,7 @@ void assemble_exterior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   // Data structures used in assembly
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
@@ -173,7 +174,7 @@ void assemble_exterior_facets(
   const int ndim0 = bs0 * num_dofs0;
   const int ndim1 = bs1 * num_dofs1;
   std::vector<T> Ae(ndim0 * ndim1);
-  const xtl::span<T> _Ae(Ae);
+  const std::span<T> _Ae(Ae);
   assert(facets.size() % 2 == 0);
   for (std::size_t index = 0; index < facets.size(); index += 2)
   {
@@ -239,22 +240,22 @@ void assemble_exterior_facets(
 template <typename T, typename U>
 void assemble_interior_facets(
     U mat_set, const mesh::Mesh& mesh,
-    const xtl::span<const std::int32_t>& facets,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::span<const std::int32_t>& facets,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
     const DofMap& dofmap0, int bs0,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
-    const DofMap& dofmap1, int bs1, const xtl::span<const std::int8_t>& bc0,
-    const xtl::span<const std::int8_t>& bc1,
+    const DofMap& dofmap1, int bs1, const std::span<const std::int8_t>& bc0,
+    const std::span<const std::int8_t>& bc1,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& kernel,
-    const xtl::span<const T>& coeffs, int cstride,
-    const xtl::span<const int>& offsets, const xtl::span<const T>& constants,
-    const xtl::span<const std::uint32_t>& cell_info,
+    const std::span<const T>& coeffs, int cstride,
+    const std::span<const int>& offsets, const std::span<const T>& constants,
+    const std::span<const std::uint32_t>& cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm)
 {
   if (facets.empty())
@@ -265,10 +266,14 @@ void assemble_interior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   // Data structures used in assembly
-  xt::xtensor<scalar_value_type_t<T>, 3> coordinate_dofs({2, num_dofs_g, 3});
+  using X = scalar_value_type_t<T>;
+  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
+
   std::vector<T> Ae, be;
   std::vector<T> coeff_array(2 * offsets.back());
   assert(offsets.back() == cstride);
@@ -289,28 +294,26 @@ void assemble_interior_facets(
     auto x_dofs0 = x_dofmap.links(cells[0]);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs0[i]),
-          xt::view(coordinate_dofs, 0, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs0[i]),
+                              std::next(cdofs0.begin(), 3 * i));
     }
     auto x_dofs1 = x_dofmap.links(cells[1]);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs1[i]),
-          xt::view(coordinate_dofs, 1, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs1[i]),
+                              std::next(cdofs1.begin(), 3 * i));
     }
 
     // Get dof maps for cells and pack
-    xtl::span<const std::int32_t> dmap0_cell0 = dofmap0.cell_dofs(cells[0]);
-    xtl::span<const std::int32_t> dmap0_cell1 = dofmap0.cell_dofs(cells[1]);
+    std::span<const std::int32_t> dmap0_cell0 = dofmap0.cell_dofs(cells[0]);
+    std::span<const std::int32_t> dmap0_cell1 = dofmap0.cell_dofs(cells[1]);
     dmapjoint0.resize(dmap0_cell0.size() + dmap0_cell1.size());
     std::copy(dmap0_cell0.begin(), dmap0_cell0.end(), dmapjoint0.begin());
     std::copy(dmap0_cell1.begin(), dmap0_cell1.end(),
               std::next(dmapjoint0.begin(), dmap0_cell0.size()));
 
-    xtl::span<const std::int32_t> dmap1_cell0 = dofmap1.cell_dofs(cells[0]);
-    xtl::span<const std::int32_t> dmap1_cell1 = dofmap1.cell_dofs(cells[1]);
+    std::span<const std::int32_t> dmap1_cell0 = dofmap1.cell_dofs(cells[0]);
+    std::span<const std::int32_t> dmap1_cell1 = dofmap1.cell_dofs(cells[1]);
     dmapjoint1.resize(dmap1_cell0.size() + dmap1_cell1.size());
     std::copy(dmap1_cell0.begin(), dmap1_cell0.end(), dmapjoint1.begin());
     std::copy(dmap1_cell1.begin(), dmap1_cell1.end(),
@@ -329,12 +332,12 @@ void assemble_interior_facets(
     kernel(Ae.data(), coeffs.data() + index / 2 * cstride, constants.data(),
            coordinate_dofs.data(), local_facet.data(), perm.data());
 
-    const xtl::span<T> _Ae(Ae);
+    const std::span<T> _Ae(Ae);
 
-    const xtl::span<T> sub_Ae0
+    const std::span<T> sub_Ae0
         = _Ae.subspan(bs0 * dmap0_cell0.size() * num_cols,
                       bs0 * dmap0_cell1.size() * num_cols);
-    const xtl::span<T> sub_Ae1
+    const std::span<T> sub_Ae1
         = _Ae.subspan(bs1 * dmap1_cell0.size(),
                       num_rows * num_cols - bs1 * dmap1_cell0.size());
 
@@ -386,11 +389,11 @@ void assemble_interior_facets(
 
 template <typename T, typename U>
 void assemble_matrix(
-    U mat_set, const Form<T>& a, const xtl::span<const T>& constants,
+    U mat_set, const Form<T>& a, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients,
-    const xtl::span<const std::int8_t>& bc0,
-    const xtl::span<const std::int8_t>& bc1)
+                   std::pair<std::span<const T>, int>>& coefficients,
+    const std::span<const std::int8_t>& bc0,
+    const std::span<const std::int8_t>& bc1)
 {
   std::shared_ptr<const mesh::Mesh> mesh = a.mesh();
   assert(mesh);
@@ -411,12 +414,12 @@ void assemble_matrix(
       = a.function_spaces().at(0)->element();
   std::shared_ptr<const fem::FiniteElement> element1
       = a.function_spaces().at(1)->element();
-  const std::function<void(const xtl::span<T>&,
-                           const xtl::span<const std::uint32_t>&, std::int32_t,
+  const std::function<void(const std::span<T>&,
+                           const std::span<const std::uint32_t>&, std::int32_t,
                            int)>& dof_transform
       = element0->get_dof_transformation_function<T>();
-  const std::function<void(const xtl::span<T>&,
-                           const xtl::span<const std::uint32_t>&, std::int32_t,
+  const std::function<void(const std::span<T>&,
+                           const std::span<const std::uint32_t>&, std::int32_t,
                            int)>& dof_transform_to_transpose
       = element1->get_dof_transformation_to_transpose_function<T>();
 
@@ -424,11 +427,11 @@ void assemble_matrix(
       = element0->needs_dof_transformations()
         or element1->needs_dof_transformations()
         or a.needs_facet_permutations();
-  xtl::span<const std::uint32_t> cell_info;
+  std::span<const std::uint32_t> cell_info;
   if (needs_transformation_data)
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
 
   for (int i : a.integral_ids(IntegralType::cell))

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -24,12 +24,12 @@ namespace dolfinx::fem::impl
 /// Assemble functional over cells
 template <typename T>
 T assemble_cells(const mesh::Geometry& geometry,
-                 const xtl::span<const std::int32_t>& cells,
+                 const std::span<const std::int32_t>& cells,
                  const std::function<void(T*, const T*, const T*,
                                           const scalar_value_type_t<T>*,
                                           const int*, const std::uint8_t*)>& fn,
-                 const xtl::span<const T>& constants,
-                 const xtl::span<const T>& coeffs, int cstride)
+                 const std::span<const T>& constants,
+                 const std::span<const T>& coeffs, int cstride)
 {
   T value(0);
   if (cells.empty())
@@ -38,7 +38,7 @@ T assemble_cells(const mesh::Geometry& geometry,
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmap().dim();
-  xtl::span<const double> x_g = geometry.x();
+  std::span<const double> x_g = geometry.x();
 
   // Create data structures used in assembly
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
@@ -67,11 +67,11 @@ T assemble_cells(const mesh::Geometry& geometry,
 /// Execute kernel over exterior facets and accumulate result
 template <typename T>
 T assemble_exterior_facets(
-    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& facets,
+    const mesh::Mesh& mesh, const std::span<const std::int32_t>& facets,
     const std::function<void(T*, const T*, const T*,
-                             const scalar_value_type_t<T>*,
-                             const int*, const std::uint8_t*)>& fn,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
+                             const scalar_value_type_t<T>*, const int*,
+                             const std::uint8_t*)>& fn,
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
     int cstride)
 {
   T value(0);
@@ -81,7 +81,7 @@ T assemble_exterior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   // Create data structures used in assembly
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
@@ -112,13 +112,13 @@ T assemble_exterior_facets(
 /// Assemble functional over interior facets
 template <typename T>
 T assemble_interior_facets(
-    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& facets,
+    const mesh::Mesh& mesh, const std::span<const std::int32_t>& facets,
     const std::function<void(T*, const T*, const T*,
-                             const scalar_value_type_t<T>*,
-                             const int*, const std::uint8_t*)>& fn,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
-    int cstride, const xtl::span<const int>& offsets,
-    const xtl::span<const std::uint8_t>& perms)
+                             const scalar_value_type_t<T>*, const int*,
+                             const std::uint8_t*)>& fn,
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
+    int cstride, const std::span<const int>& offsets,
+    const std::span<const std::uint8_t>& perms)
 {
   T value(0);
   if (facets.empty())
@@ -129,10 +129,14 @@ T assemble_interior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   // Create data structures used in assembly
-  xt::xtensor<scalar_value_type_t<T>, 3> coordinate_dofs({2, num_dofs_g, 3});
+  using X = scalar_value_type_t<T>;
+  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
+
   std::vector<T> coeff_array(2 * offsets.back());
   assert(offsets.back() == cstride);
 
@@ -151,16 +155,14 @@ T assemble_interior_facets(
     auto x_dofs0 = x_dofmap.links(cells[0]);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs0[i]),
-          xt::view(coordinate_dofs, 0, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs0[i]),
+                              std::next(cdofs0.begin(), 3 * i));
     }
     auto x_dofs1 = x_dofmap.links(cells[1]);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs1[i]),
-          xt::view(coordinate_dofs, 1, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs1[i]),
+                              std::next(cdofs1.begin(), 3 * i));
     }
 
     const std::array perm{perms[cells[0] * num_cell_facets + local_facet[0]],
@@ -175,9 +177,9 @@ T assemble_interior_facets(
 /// Assemble functional into an scalar
 template <typename T>
 T assemble_scalar(
-    const fem::Form<T>& M, const xtl::span<const T>& constants,
+    const fem::Form<T>& M, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients)
+                   std::pair<std::span<const T>, int>>& coefficients)
 {
   std::shared_ptr<const mesh::Mesh> mesh = M.mesh();
   assert(mesh);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -20,9 +20,8 @@
 #include <dolfinx/mesh/Topology.h>
 #include <functional>
 #include <memory>
+#include <span>
 #include <vector>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx::fem::impl
 {
@@ -38,24 +37,24 @@ namespace dolfinx::fem::impl
 /// @tparam _bs1 The block size of the trial function dof map.
 template <typename T, int _bs0 = -1, int _bs1 = -1>
 void _lift_bc_cells(
-    xtl::span<T> b, const mesh::Geometry& geometry,
+    std::span<T> b, const mesh::Geometry& geometry,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& kernel,
-    const xtl::span<const std::int32_t>& cells,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::span<const std::int32_t>& cells,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
     const graph::AdjacencyList<std::int32_t>& dofmap0, int bs0,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
-    int cstride, const xtl::span<const std::uint32_t>& cell_info,
-    const xtl::span<const T>& bc_values1,
-    const xtl::span<const std::int8_t>& bc_markers1,
-    const xtl::span<const T>& x0, double scale)
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
+    int cstride, const std::span<const std::uint32_t>& cell_info,
+    const std::span<const T>& bc_values1,
+    const std::span<const std::int8_t>& bc_markers1,
+    const std::span<const T>& x0, double scale)
 {
   assert(_bs0 < 0 or _bs0 == bs0);
   assert(_bs1 < 0 or _bs1 == bs1);
@@ -66,7 +65,7 @@ void _lift_bc_cells(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmap().dim();
-  xtl::span<const double> x_g = geometry.x();
+  std::span<const double> x_g = geometry.x();
 
   // Data structures used in bc application
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
@@ -199,24 +198,24 @@ void _lift_bc_cells(
 /// @tparam _bs1 The block size of the trial function dof map.
 template <typename T, int _bs = -1>
 void _lift_bc_exterior_facets(
-    xtl::span<T> b, const mesh::Mesh& mesh,
+    std::span<T> b, const mesh::Mesh& mesh,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& kernel,
-    const xtl::span<const std::int32_t>& facets,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::span<const std::int32_t>& facets,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
     const graph::AdjacencyList<std::int32_t>& dofmap0, int bs0,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
-    int cstride, const xtl::span<const std::uint32_t>& cell_info,
-    const xtl::span<const T>& bc_values1,
-    const xtl::span<const std::int8_t>& bc_markers1,
-    const xtl::span<const T>& x0, double scale)
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
+    int cstride, const std::span<const std::uint32_t>& cell_info,
+    const std::span<const T>& bc_values1,
+    const std::span<const std::int8_t>& bc_markers1,
+    const std::span<const T>& x0, double scale)
 {
   if (facets.empty())
     return;
@@ -224,7 +223,7 @@ void _lift_bc_exterior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   // Data structures used in bc application
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
@@ -311,25 +310,25 @@ void _lift_bc_exterior_facets(
 /// @tparam _bs1 The block size of the trial function dof map.
 template <typename T, int _bs = -1>
 void _lift_bc_interior_facets(
-    xtl::span<T> b, const mesh::Mesh& mesh,
+    std::span<T> b, const mesh::Mesh& mesh,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& kernel,
-    const xtl::span<const std::int32_t>& facets,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::span<const std::int32_t>& facets,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
     const graph::AdjacencyList<std::int32_t>& dofmap0, int bs0,
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
-    int cstride, const xtl::span<const std::uint32_t>& cell_info,
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
+    int cstride, const std::span<const std::uint32_t>& cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm,
-    const xtl::span<const T>& bc_values1,
-    const xtl::span<const std::int8_t>& bc_markers1,
-    const xtl::span<const T>& x0, double scale)
+    const std::span<const T>& bc_values1,
+    const std::span<const std::int8_t>& bc_markers1,
+    const std::span<const T>& x0, double scale)
 {
   if (facets.empty())
     return;
@@ -339,20 +338,24 @@ void _lift_bc_interior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   const int num_cell_facets
       = mesh::cell_num_entities(mesh.topology().cell_type(), tdim - 1);
 
   // Data structures used in assembly
-  xt::xtensor<scalar_value_type_t<T>, 3> coordinate_dofs({2, num_dofs_g, 3});
+  using X = scalar_value_type_t<T>;
+  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
   std::vector<T> Ae, be;
 
   // Temporaries for joint dofmaps
   std::vector<std::int32_t> dmapjoint0, dmapjoint1;
   assert(facets.size() % 4 == 0);
 
-  const scalar_value_type_t<T> _scale = static_cast<scalar_value_type_t<T>>(scale);
+  const scalar_value_type_t<T> _scale
+      = static_cast<scalar_value_type_t<T>>(scale);
   for (std::size_t index = 0; index < facets.size(); index += 4)
   {
     std::array<std::int32_t, 2> cells = {facets[index], facets[index + 2]};
@@ -363,28 +366,26 @@ void _lift_bc_interior_facets(
     auto x_dofs0 = x_dofmap.links(cells[0]);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs0[i]),
-          xt::view(coordinate_dofs, 0, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs0[i]),
+                              std::next(cdofs0.begin(), 3 * i));
     }
     auto x_dofs1 = x_dofmap.links(cells[1]);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs1[i]),
-          xt::view(coordinate_dofs, 1, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs1[i]),
+                              std::next(cdofs1.begin(), 3 * i));
     }
 
     // Get dof maps for cells and pack
-    const xtl::span<const std::int32_t> dmap0_cell0 = dofmap0.links(cells[0]);
-    const xtl::span<const std::int32_t> dmap0_cell1 = dofmap0.links(cells[1]);
+    const std::span<const std::int32_t> dmap0_cell0 = dofmap0.links(cells[0]);
+    const std::span<const std::int32_t> dmap0_cell1 = dofmap0.links(cells[1]);
     dmapjoint0.resize(dmap0_cell0.size() + dmap0_cell1.size());
     std::copy(dmap0_cell0.begin(), dmap0_cell0.end(), dmapjoint0.begin());
     std::copy(dmap0_cell1.begin(), dmap0_cell1.end(),
               std::next(dmapjoint0.begin(), dmap0_cell0.size()));
 
-    const xtl::span<const std::int32_t> dmap1_cell0 = dofmap1.links(cells[0]);
-    const xtl::span<const std::int32_t> dmap1_cell1 = dofmap1.links(cells[1]);
+    const std::span<const std::int32_t> dmap1_cell0 = dofmap1.links(cells[0]);
+    const std::span<const std::int32_t> dmap1_cell1 = dofmap1.links(cells[1]);
     dmapjoint1.resize(dmap1_cell0.size() + dmap1_cell1.size());
     std::copy(dmap1_cell0.begin(), dmap1_cell0.end(), dmapjoint1.begin());
     std::copy(dmap1_cell1.begin(), dmap1_cell1.end(),
@@ -432,11 +433,11 @@ void _lift_bc_interior_facets(
     kernel(Ae.data(), coeffs.data() + index / 2 * cstride, constants.data(),
            coordinate_dofs.data(), local_facet.data(), perm.data());
 
-    const xtl::span<T> _Ae(Ae);
-    const xtl::span<T> sub_Ae0
+    const std::span<T> _Ae(Ae);
+    const std::span<T> sub_Ae0
         = _Ae.subspan(bs0 * dmap0_cell0.size() * num_cols,
                       bs0 * dmap0_cell1.size() * num_cols);
-    const xtl::span<T> sub_Ae1
+    const std::span<T> sub_Ae1
         = _Ae.subspan(bs1 * dmap1_cell0.size(),
                       num_rows * num_cols - bs1 * dmap1_cell0.size());
 
@@ -504,17 +505,17 @@ void _lift_bc_interior_facets(
 /// has performance benefits.
 template <typename T, int _bs = -1>
 void assemble_cells(
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
-    xtl::span<T> b, const mesh::Geometry& geometry,
-    const xtl::span<const std::int32_t>& cells,
+    std::span<T> b, const mesh::Geometry& geometry,
+    const std::span<const std::int32_t>& cells,
     const graph::AdjacencyList<std::int32_t>& dofmap, int bs,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& kernel,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
-    int cstride, const xtl::span<const std::uint32_t>& cell_info)
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
+    int cstride, const std::span<const std::uint32_t>& cell_info)
 {
   assert(_bs < 0 or _bs == bs);
 
@@ -524,14 +525,14 @@ void assemble_cells(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmap().dim();
-  xtl::span<const double> x_g = geometry.x();
+  std::span<const double> x_g = geometry.x();
 
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
   const int num_dofs = dofmap.links(0).size();
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
   std::vector<T> be(bs * num_dofs);
-  const xtl::span<T> _be(be);
+  const std::span<T> _be(be);
 
   // Iterate over active cells
   for (std::size_t index = 0; index < cells.size(); ++index)
@@ -577,17 +578,17 @@ void assemble_cells(
 /// has performance benefits.
 template <typename T, int _bs = -1>
 void assemble_exterior_facets(
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
-    xtl::span<T> b, const mesh::Mesh& mesh,
-    const xtl::span<const std::int32_t>& facets,
+    std::span<T> b, const mesh::Mesh& mesh,
+    const std::span<const std::int32_t>& facets,
     const graph::AdjacencyList<std::int32_t>& dofmap, int bs,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& fn,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
-    int cstride, const xtl::span<const std::uint32_t>& cell_info)
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
+    int cstride, const std::span<const std::uint32_t>& cell_info)
 {
   assert(_bs < 0 or _bs == bs);
 
@@ -597,14 +598,14 @@ void assemble_exterior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
   const int num_dofs = dofmap.links(0).size();
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
   std::vector<T> be(bs * num_dofs);
-  const xtl::span<T> _be(be);
+  const std::span<T> _be(be);
   assert(facets.size() % 2 == 0);
   for (std::size_t index = 0; index < facets.size(); index += 2)
   {
@@ -651,16 +652,16 @@ void assemble_exterior_facets(
 /// has performance benefits.
 template <typename T, int _bs = -1>
 void assemble_interior_facets(
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
-    xtl::span<T> b, const mesh::Mesh& mesh,
-    const xtl::span<const std::int32_t>& facets, const fem::DofMap& dofmap,
+    std::span<T> b, const mesh::Mesh& mesh,
+    const std::span<const std::int32_t>& facets, const fem::DofMap& dofmap,
     const std::function<void(T*, const T*, const T*,
                              const scalar_value_type_t<T>*, const int*,
                              const std::uint8_t*)>& fn,
-    const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
-    int cstride, const xtl::span<const std::uint32_t>& cell_info,
+    const std::span<const T>& constants, const std::span<const T>& coeffs,
+    int cstride, const std::span<const std::uint32_t>& cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm)
 {
   const int tdim = mesh.topology().dim();
@@ -668,10 +669,13 @@ void assemble_interior_facets(
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const std::size_t num_dofs_g = mesh.geometry().cmap().dim();
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
 
   // Create data structures used in assembly
-  xt::xtensor<scalar_value_type_t<T>, 3> coordinate_dofs({2, num_dofs_g, 3});
+  using X = scalar_value_type_t<T>;
+  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
   std::vector<T> be;
 
   const int num_cell_facets
@@ -690,21 +694,19 @@ void assemble_interior_facets(
     auto x_dofs0 = x_dofmap.links(cells[0]);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs0[i]),
-          xt::view(coordinate_dofs, 0, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs0[i]),
+                              std::next(cdofs0.begin(), 3 * i));
     }
     auto x_dofs1 = x_dofmap.links(cells[1]);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
-      common::impl::copy_N<3>(
-          std::next(x_g.begin(), 3 * x_dofs1[i]),
-          xt::view(coordinate_dofs, 1, i, xt::all()).begin());
+      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs1[i]),
+                              std::next(cdofs1.begin(), 3 * i));
     }
 
     // Get dofmaps for cells
-    xtl::span<const std::int32_t> dmap0 = dofmap.cell_dofs(cells[0]);
-    xtl::span<const std::int32_t> dmap1 = dofmap.cell_dofs(cells[1]);
+    std::span<const std::int32_t> dmap0 = dofmap.cell_dofs(cells[0]);
+    std::span<const std::int32_t> dmap1 = dofmap.cell_dofs(cells[1]);
 
     // Tabulate element vector
     be.resize(bs * (dmap0.size() + dmap1.size()));
@@ -715,8 +717,8 @@ void assemble_interior_facets(
     fn(be.data(), coeffs.data() + index / 2 * cstride, constants.data(),
        coordinate_dofs.data(), local_facet.data(), perm.data());
 
-    const xtl::span<T> _be(be);
-    const xtl::span<T> sub_be
+    const std::span<T> _be(be);
+    const std::span<T> sub_be
         = _be.subspan(bs * dmap0.size(), bs * dmap1.size());
 
     dof_transform(be, cell_info, cells[0], 1);
@@ -759,13 +761,13 @@ void assemble_interior_facets(
 /// solution' in a Newton method
 /// @param[in] scale Scaling to apply
 template <typename T>
-void lift_bc(xtl::span<T> b, const Form<T>& a,
-             const xtl::span<const T>& constants,
+void lift_bc(std::span<T> b, const Form<T>& a,
+             const std::span<const T>& constants,
              const std::map<std::pair<IntegralType, int>,
-                            std::pair<xtl::span<const T>, int>>& coefficients,
-             const xtl::span<const T>& bc_values1,
-             const xtl::span<const std::int8_t>& bc_markers1,
-             const xtl::span<const T>& x0, double scale)
+                            std::pair<std::span<const T>, int>>& coefficients,
+             const std::span<const T>& bc_values1,
+             const std::span<const std::int8_t>& bc_markers1,
+             const std::span<const T>& x0, double scale)
 {
   std::shared_ptr<const mesh::Mesh> mesh = a.mesh();
   assert(mesh);
@@ -789,19 +791,19 @@ void lift_bc(xtl::span<T> b, const Form<T>& a,
         or element1->needs_dof_transformations()
         or a.needs_facet_permutations();
 
-  xtl::span<const std::uint32_t> cell_info;
+  std::span<const std::uint32_t> cell_info;
   if (needs_transformation_data)
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
 
-  const std::function<void(const xtl::span<T>&,
-                           const xtl::span<const std::uint32_t>&, std::int32_t,
+  const std::function<void(const std::span<T>&,
+                           const std::span<const std::uint32_t>&, std::int32_t,
                            int)>
       dof_transform = element0->get_dof_transformation_function<T>();
-  const std::function<void(const xtl::span<T>&,
-                           const xtl::span<const std::uint32_t>&, std::int32_t,
+  const std::function<void(const std::span<T>&,
+                           const std::span<const std::uint32_t>&, std::int32_t,
                            int)>
       dof_transform_to_transpose
       = element1->get_dof_transformation_to_transpose_function<T>();
@@ -894,12 +896,12 @@ void lift_bc(xtl::span<T> b, const Form<T>& a,
 /// @param[in] scale Scaling to apply
 template <typename T>
 void apply_lifting(
-    xtl::span<T> b, const std::vector<std::shared_ptr<const Form<T>>> a,
-    const std::vector<xtl::span<const T>>& constants,
+    std::span<T> b, const std::vector<std::shared_ptr<const Form<T>>> a,
+    const std::vector<std::span<const T>>& constants,
     const std::vector<std::map<std::pair<IntegralType, int>,
-                               std::pair<xtl::span<const T>, int>>>& coeffs,
+                               std::pair<std::span<const T>, int>>>& coeffs,
     const std::vector<std::vector<std::shared_ptr<const DirichletBC<T>>>>& bcs1,
-    const std::vector<xtl::span<const T>>& x0, double scale)
+    const std::vector<std::span<const T>>& x0, double scale)
 {
   // FIXME: make changes to reactivate this check
   if (!x0.empty() and x0.size() != a.size())
@@ -944,7 +946,7 @@ void apply_lifting(
       else
       {
         lift_bc<T>(b, *a[j], constants[j], coeffs[j], bc_values1, bc_markers1,
-                   xtl::span<const T>(), scale);
+                   std::span<const T>(), scale);
       }
     }
   }
@@ -958,9 +960,9 @@ void apply_lifting(
 /// @param[in] coefficients Packed coefficients that appear in `L`
 template <typename T>
 void assemble_vector(
-    xtl::span<T> b, const Form<T>& L, const xtl::span<const T>& constants,
+    std::span<T> b, const Form<T>& L, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients)
+                   std::pair<std::span<const T>, int>>& coefficients)
 {
   std::shared_ptr<const mesh::Mesh> mesh = L.mesh();
   assert(mesh);
@@ -975,18 +977,18 @@ void assemble_vector(
   const graph::AdjacencyList<std::int32_t>& dofs = dofmap->list();
   const int bs = dofmap->bs();
 
-  const std::function<void(const xtl::span<T>&,
-                           const xtl::span<const std::uint32_t>&, std::int32_t,
+  const std::function<void(const std::span<T>&,
+                           const std::span<const std::uint32_t>&, std::int32_t,
                            int)>
       dof_transform = element->get_dof_transformation_function<T>();
 
   const bool needs_transformation_data
       = element->needs_dof_transformations() or L.needs_facet_permutations();
-  xtl::span<const std::uint32_t> cell_info;
+  std::span<const std::uint32_t> cell_info;
   if (needs_transformation_data)
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
 
   for (int i : L.integral_ids(IntegralType::cell))

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -11,8 +11,8 @@
 #include "assemble_vector_impl.h"
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::fem
 {
@@ -24,15 +24,15 @@ class FunctionSpace;
 
 // -- Helper functions -----------------------------------------------------
 
-/// @brief Create a map xtl::span from a map of std::vector
+/// @brief Create a map std::span from a map of std::vector
 template <typename T>
 std::map<std::pair<dolfinx::fem::IntegralType, int>,
-         std::pair<xtl::span<const T>, int>>
+         std::pair<std::span<const T>, int>>
 make_coefficients_span(const std::map<std::pair<IntegralType, int>,
                                       std::pair<std::vector<T>, int>>& coeffs)
 {
   using Key = typename std::remove_reference_t<decltype(coeffs)>::key_type;
-  std::map<Key, std::pair<xtl::span<const T>, int>> c;
+  std::map<Key, std::pair<std::span<const T>, int>> c;
   std::transform(coeffs.cbegin(), coeffs.cend(), std::inserter(c, c.end()),
                  [](auto& e) -> typename decltype(c)::value_type {
                    return {e.first, {e.second.first, e.second.second}};
@@ -53,9 +53,9 @@ make_coefficients_span(const std::map<std::pair<IntegralType, int>,
 /// process
 template <typename T>
 T assemble_scalar(
-    const Form<T>& M, const xtl::span<const T>& constants,
+    const Form<T>& M, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients)
+                   std::pair<std::span<const T>, int>>& coefficients)
 {
   return impl::assemble_scalar(M, constants, coefficients);
 }
@@ -71,7 +71,7 @@ T assemble_scalar(const Form<T>& M)
   const std::vector<T> constants = pack_constants(M);
   auto coefficients = allocate_coefficient_storage(M);
   pack_coefficients(M, coefficients);
-  return assemble_scalar(M, tcb::make_span(constants),
+  return assemble_scalar(M, std::span(constants),
                          make_coefficients_span(coefficients));
 }
 
@@ -87,9 +87,9 @@ T assemble_scalar(const Form<T>& M)
 /// @param[in] coefficients The coefficients that appear in `L`
 template <typename T>
 void assemble_vector(
-    xtl::span<T> b, const Form<T>& L, const xtl::span<const T>& constants,
+    std::span<T> b, const Form<T>& L, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients)
+                   std::pair<std::span<const T>, int>>& coefficients)
 {
   impl::assemble_vector(b, L, constants, coefficients);
 }
@@ -99,12 +99,12 @@ void assemble_vector(
 /// before assembly.
 /// @param[in] L The linear forms to assemble into b
 template <typename T>
-void assemble_vector(xtl::span<T> b, const Form<T>& L)
+void assemble_vector(std::span<T> b, const Form<T>& L)
 {
   auto coefficients = allocate_coefficient_storage(L);
   pack_coefficients(L, coefficients);
   const std::vector<T> constants = pack_constants(L);
-  assemble_vector(b, L, tcb::make_span(constants),
+  assemble_vector(b, L, std::span(constants),
                   make_coefficients_span(coefficients));
 }
 
@@ -128,12 +128,12 @@ void assemble_vector(xtl::span<T> b, const Form<T>& L)
 /// is responsible for calling VecGhostUpdateBegin/End.
 template <typename T>
 void apply_lifting(
-    xtl::span<T> b, const std::vector<std::shared_ptr<const Form<T>>>& a,
-    const std::vector<xtl::span<const T>>& constants,
+    std::span<T> b, const std::vector<std::shared_ptr<const Form<T>>>& a,
+    const std::vector<std::span<const T>>& constants,
     const std::vector<std::map<std::pair<IntegralType, int>,
-                               std::pair<xtl::span<const T>, int>>>& coeffs,
+                               std::pair<std::span<const T>, int>>>& coeffs,
     const std::vector<std::vector<std::shared_ptr<const DirichletBC<T>>>>& bcs1,
-    const std::vector<xtl::span<const T>>& x0, double scale)
+    const std::vector<std::span<const T>>& x0, double scale)
 {
   impl::apply_lifting(b, a, constants, coeffs, bcs1, x0, scale);
 }
@@ -152,9 +152,9 @@ void apply_lifting(
 /// is responsible for calling VecGhostUpdateBegin/End.
 template <typename T>
 void apply_lifting(
-    xtl::span<T> b, const std::vector<std::shared_ptr<const Form<T>>>& a,
+    std::span<T> b, const std::vector<std::shared_ptr<const Form<T>>>& a,
     const std::vector<std::vector<std::shared_ptr<const DirichletBC<T>>>>& bcs1,
-    const std::vector<xtl::span<const T>>& x0, double scale)
+    const std::vector<std::span<const T>>& x0, double scale)
 {
   std::vector<
       std::map<std::pair<IntegralType, int>, std::pair<std::vector<T>, int>>>
@@ -177,10 +177,10 @@ void apply_lifting(
     }
   }
 
-  std::vector<xtl::span<const T>> _constants(constants.begin(),
+  std::vector<std::span<const T>> _constants(constants.begin(),
                                              constants.end());
   std::vector<std::map<std::pair<IntegralType, int>,
-                       std::pair<xtl::span<const T>, int>>>
+                       std::pair<std::span<const T>, int>>>
       _coeffs;
   std::transform(coeffs.cbegin(), coeffs.cend(), std::back_inserter(_coeffs),
                  [](auto& c) { return make_coefficients_span(c); });
@@ -198,9 +198,9 @@ void apply_lifting(
 ///  dofs the row and column are zeroed. The diagonal  entry is not set.
 template <typename T, typename U>
 void assemble_matrix(
-    U mat_add, const Form<T>& a, const xtl::span<const T>& constants,
+    U mat_add, const Form<T>& a, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients,
+                   std::pair<std::span<const T>, int>>& coefficients,
     const std::vector<std::shared_ptr<const DirichletBC<T>>>& bcs)
 {
   // Index maps for dof ranges
@@ -253,7 +253,7 @@ void assemble_matrix(
   pack_coefficients(a, coefficients);
 
   // Assemble
-  assemble_matrix(mat_add, a, tcb::make_span(constants),
+  assemble_matrix(mat_add, a, std::span(constants),
                   make_coefficients_span(coefficients), bcs);
 }
 
@@ -271,11 +271,11 @@ void assemble_matrix(
 /// local index.
 template <typename T, typename U>
 void assemble_matrix(
-    U mat_add, const Form<T>& a, const xtl::span<const T>& constants,
+    U mat_add, const Form<T>& a, const std::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const T>, int>>& coefficients,
-    const xtl::span<const std::int8_t>& dof_marker0,
-    const xtl::span<const std::int8_t>& dof_marker1)
+                   std::pair<std::span<const T>, int>>& coefficients,
+    const std::span<const std::int8_t>& dof_marker0,
+    const std::span<const std::int8_t>& dof_marker1)
 
 {
   impl::assemble_matrix(mat_add, a, constants, coefficients, dof_marker0,
@@ -294,8 +294,8 @@ void assemble_matrix(
 ///   local index.
 template <typename T, typename U>
 void assemble_matrix(U mat_add, const Form<T>& a,
-                     const xtl::span<const std::int8_t>& dof_marker0,
-                     const xtl::span<const std::int8_t>& dof_marker1)
+                     const std::span<const std::int8_t>& dof_marker0,
+                     const std::span<const std::int8_t>& dof_marker1)
 
 {
   // Prepare constants and coefficients
@@ -304,7 +304,7 @@ void assemble_matrix(U mat_add, const Form<T>& a,
   pack_coefficients(a, coefficients);
 
   // Assemble
-  assemble_matrix(mat_add, a, tcb::make_span(constants),
+  assemble_matrix(mat_add, a, std::span(constants),
                   make_coefficients_span(coefficients), dof_marker0,
                   dof_marker1);
 }
@@ -320,12 +320,12 @@ void assemble_matrix(U mat_add, const Form<T>& a,
 /// @param[in] diagonal The value to add to the diagonal for the
 ///   specified rows
 template <typename T, typename U>
-void set_diagonal(U set_fn, const xtl::span<const std::int32_t>& rows,
+void set_diagonal(U set_fn, const std::span<const std::int32_t>& rows,
                   T diagonal = 1.0)
 {
   for (std::size_t i = 0; i < rows.size(); ++i)
   {
-    xtl::span diag_span(&diagonal, 1);
+    std::span diag_span(&diagonal, 1);
     set_fn(rows.subspan(i, 1), rows.subspan(i, 1), diag_span);
   }
 }
@@ -372,9 +372,9 @@ void set_diagonal(U set_fn, const fem::FunctionSpace& V,
 /// 'scale'. The vectors b and x0 must have the same local size. The bcs
 /// should be on (sub-)spaces of the form L that b represents.
 template <typename T>
-void set_bc(xtl::span<T> b,
+void set_bc(std::span<T> b,
             const std::vector<std::shared_ptr<const DirichletBC<T>>>& bcs,
-            const xtl::span<const T>& x0, double scale = 1.0)
+            const std::span<const T>& x0, double scale = 1.0)
 {
   if (b.size() > x0.size())
     throw std::runtime_error("Size mismatch between b and x0 vectors.");
@@ -389,7 +389,7 @@ void set_bc(xtl::span<T> b,
 /// 'scale'. The bcs should be on (sub-)spaces of the form L that b
 /// represents.
 template <typename T>
-void set_bc(xtl::span<T> b,
+void set_bc(std::span<T> b,
             const std::vector<std::shared_ptr<const DirichletBC<T>>>& bcs,
             double scale = 1.0)
 {

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -15,12 +15,8 @@
 #include <dolfinx/common/utils.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <memory>
+#include <span>
 #include <vector>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xindex_view.hpp>
-#include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::fem
 {
@@ -52,6 +48,13 @@ template <typename T, typename U>
 void discrete_gradient(const FunctionSpace& V0, const FunctionSpace& V1,
                        U&& mat_set)
 {
+  namespace stdex = std::experimental;
+  using cmdspan2_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan4_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+
   // Get mesh
   std::shared_ptr<const mesh::Mesh> mesh = V1.mesh();
   assert(mesh);
@@ -74,22 +77,21 @@ void discrete_gradient(const FunctionSpace& V0, const FunctionSpace& V1,
     throw std::runtime_error("Block size is greather than 1 for V1.");
 
   // Get V0 (H(curl)) space interpolation points
-  const xt::xtensor<double, 2> X = e1->interpolation_points();
+  const auto [X, Xshape] = e1->interpolation_points();
 
   // Tabulate first order derivatives of Lagrange space at H(curl)
   // interpolation points
   const int ndofs0 = e0->space_dimension();
   const int tdim = mesh->topology().dim();
-  xt::xtensor<double, 4> phi0
-      = xt::empty<double>({tdim + 1, int(X.shape(0)), ndofs0, 1});
-  e0->tabulate(phi0, X, 1);
+  std::vector<double> phi0_b((tdim + 1) * Xshape[0] * ndofs0 * 1);
+  cmdspan4_t phi0(phi0_b.data(), tdim + 1, Xshape[0], ndofs0, 1);
+  e0->tabulate(phi0_b, X, Xshape, 1);
 
   // Reshape lagrange basis derivatives as a matrix of shape (tdim *
   // num_points, num_dofs_per_cell)
-  auto dphi0 = xt::view(phi0, xt::xrange(std::size_t(1), phi0.shape(0)),
-                        xt::all(), xt::all(), 0);
-  auto dphi_reshaped
-      = xt::reshape_view(dphi0, {tdim * phi0.shape(1), phi0.shape(2)});
+  cmdspan2_t dphi_reshaped(
+      phi0_b.data() + phi0.extent(3) * phi0.extent(2) * phi0.extent(1),
+      tdim * phi0.extent(1), phi0.extent(2));
 
   // Get inverse DOF transform function
   auto apply_inverse_dof_transform
@@ -107,27 +109,29 @@ void discrete_gradient(const FunctionSpace& V0, const FunctionSpace& V1,
   assert(dofmap1);
 
   // Build the element interpolation matrix
-  std::vector<T> A(e1->space_dimension() * ndofs0);
+  std::vector<T> Ab(e1->space_dimension() * ndofs0);
   {
-    auto _A = xt::adapt(A, std::vector<int>{e1->space_dimension(), ndofs0});
-    const xt::xtensor<double, 2> Pi = e1->interpolation_operator();
-    math::dot(Pi, dphi_reshaped, _A);
+    stdex::mdspan<T, stdex::dextents<std::size_t, 2>> A(
+        Ab.data(), e1->space_dimension(), ndofs0);
+    const auto [Pi, shape] = e1->interpolation_operator();
+    cmdspan2_t _Pi(Pi.data(), shape);
+    math::dot(_Pi, dphi_reshaped, A);
   }
 
   // Insert local interpolation matrix for each cell
   auto cell_map = mesh->topology().index_map(tdim);
   assert(cell_map);
   std::int32_t num_cells = cell_map->size_local();
-  std::vector<T> Ae(A.size());
+  std::vector<T> Ae(Ab.size());
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
-    std::copy(A.cbegin(), A.cend(), Ae.begin());
+    std::copy(Ab.cbegin(), Ab.cend(), Ae.begin());
     apply_inverse_dof_transform(Ae, cell_info, c, ndofs0);
     mat_set(dofmap1->cell_dofs(c), dofmap0->cell_dofs(c), Ae);
   }
 }
 
-/// @brief Assemble an interpolation operator matrix
+/// @brief Assemble an interpolation operator matrix.
 ///
 /// The interpolation operator \f$A\f$ interpolates a function in the
 /// space \f$V_0\f$ into a space \f$V_1\f$. If \f$u_0\f$ is the
@@ -155,189 +159,227 @@ void interpolation_matrix(const FunctionSpace& V0, const FunctionSpace& V1,
   const int gdim = mesh->geometry().dim();
 
   // Get elements
-  std::shared_ptr<const FiniteElement> element0 = V0.element();
-  assert(element0);
-  std::shared_ptr<const FiniteElement> element1 = V1.element();
-  assert(element1);
+  std::shared_ptr<const FiniteElement> e0 = V0.element();
+  assert(e0);
+  std::shared_ptr<const FiniteElement> e1 = V1.element();
+  assert(e1);
 
-  xtl::span<const std::uint32_t> cell_info;
-  if (element1->needs_dof_transformations()
-      or element0->needs_dof_transformations())
+  std::span<const std::uint32_t> cell_info;
+  if (e1->needs_dof_transformations() or e0->needs_dof_transformations())
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
 
   // Get dofmaps
   auto dofmap0 = V0.dofmap();
+  assert(dofmap0);
   auto dofmap1 = V1.dofmap();
+  assert(dofmap1);
 
   // Get block sizes and dof transformation operators
-  const int bs0 = element0->block_size();
-  const int bs1 = element1->block_size();
+  const int bs0 = e0->block_size();
+  const int bs1 = e1->block_size();
   const auto apply_dof_transformation0
-      = element0->get_dof_transformation_function<double>(false, false, false);
+      = e0->get_dof_transformation_function<double>(false, false, false);
   const auto apply_inverse_dof_transform1
-      = element1->get_dof_transformation_function<T>(true, true, false);
+      = e1->get_dof_transformation_function<T>(true, true, false);
 
   // Get sizes of elements
-  const std::size_t space_dim0 = element0->space_dimension();
-  const std::size_t space_dim1 = element1->space_dimension();
+  const std::size_t space_dim0 = e0->space_dimension();
+  const std::size_t space_dim1 = e1->space_dimension();
   const std::size_t dim0 = space_dim0 / bs0;
-  const std::size_t value_size_ref0 = element0->reference_value_size() / bs0;
-  const std::size_t value_size0 = element0->value_size() / bs0;
-  const std::size_t value_size1 = element1->value_size() / bs1;
+  const std::size_t value_size_ref0 = e0->reference_value_size() / bs0;
+  const std::size_t value_size0 = e0->value_size() / bs0;
+  const std::size_t value_size1 = e1->value_size() / bs1;
 
   // Get geometry data
   const CoordinateElement& cmap = mesh->geometry().cmap();
   const graph::AdjacencyList<std::int32_t>& x_dofmap
       = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
-  xtl::span<const double> x_g = mesh->geometry().x();
+  std::span<const double> x_g = mesh->geometry().x();
+
+  namespace stdex = std::experimental;
+  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan2_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan3_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 3>>;
+  using cmdspan4_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
+
+  // TODO: the below has a bug - for non-affine maps the basis needs to
+  // be evaluated at every point. See
+  // https://github.com/FEniCS/dolfinx/issues/2275.
 
   // Evaluate coordinate map basis at reference interpolation points
-  const xt::xtensor<double, 2> X = element1->interpolation_points();
-  xt::xtensor<double, 4> phi(cmap.tabulate_shape(1, X.shape(0)));
-  cmap.tabulate(1, X, phi);
-  const xt::xtensor<double, 2> dphi
-      = xt::view(phi, xt::range(1, tdim + 1), 0, xt::all(), 0);
+  const auto [X, Xshape] = e1->interpolation_points();
+  std::array<std::size_t, 4> phi_shape = cmap.tabulate_shape(1, Xshape[0]);
+  std::vector<double> phi_b(
+      std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+  cmdspan4_t phi(phi_b.data(), phi_shape);
+  cmap.tabulate(1, X, Xshape, phi_b);
+  auto dphi
+      = stdex::submdspan(phi, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
 
   // Evaluate V0 basis functions at reference interpolation points for V1
-  xt::xtensor<double, 4> basis_derivatives_reference0(
-      {1, X.shape(0), dim0, value_size_ref0});
-  element0->tabulate(basis_derivatives_reference0, X, 0);
+  std::vector<double> basis_derivatives_reference0_b(Xshape[0] * dim0
+                                                     * value_size_ref0);
+  cmdspan4_t basis_derivatives_reference0(basis_derivatives_reference0_b.data(),
+                                          1, Xshape[0], dim0, value_size_ref0);
+  e0->tabulate(basis_derivatives_reference0_b, X, Xshape, 0);
 
-  constexpr double rtol = 1e-14;
-  constexpr double atol = 1e-14;
-  auto inds = xt::isclose(basis_derivatives_reference0, 0.0, rtol, atol);
-  xt::filtration(basis_derivatives_reference0, inds) = 0.0;
+  // Clamp values
+  std::transform(basis_derivatives_reference0_b.begin(),
+                 basis_derivatives_reference0_b.end(),
+                 basis_derivatives_reference0_b.begin(),
+                 [atol = 1e-14](auto x)
+                 { return std::abs(x) < atol ? 0.0 : x; });
 
   // Create working arrays
-  xt::xtensor<double, 3> basis_reference0({X.shape(0), dim0, value_size_ref0});
-  xt::xtensor<double, 3> J({X.shape(0), gdim, tdim});
-  xt::xtensor<double, 3> K({X.shape(0), tdim, gdim});
-  std::vector<double> detJ(X.shape(0));
+  std::vector<double> basis_reference0_b(Xshape[0] * dim0 * value_size_ref0);
+  mdspan3_t basis_reference0(basis_reference0_b.data(), Xshape[0], dim0,
+                             value_size_ref0);
+  std::vector<double> J_b(Xshape[0] * gdim * tdim);
+  mdspan3_t J(J_b.data(), Xshape[0], gdim, tdim);
+  std::vector<double> K_b(Xshape[0] * tdim * gdim);
+  mdspan3_t K(K_b.data(), Xshape[0], tdim, gdim);
+  std::vector<double> detJ(Xshape[0]);
+  std::vector<double> det_scratch(2 * tdim * gdim);
 
   // Get the interpolation operator (matrix) `Pi` that maps a function
   // evaluated at the interpolation points to the element degrees of
   // freedom, i.e. dofs = Pi f_x
-  const xt::xtensor<double, 2>& Pi_1 = element1->interpolation_operator();
-  bool interpolation_ident = element1->interpolation_ident();
+  const auto [_Pi_1, pi_shape] = e1->interpolation_operator();
+  cmdspan2_t Pi_1(_Pi_1.data(), pi_shape);
+
+  bool interpolation_ident = e1->interpolation_ident();
 
   namespace stdex = std::experimental;
   using u_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
   using U_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
   using J_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
   using K_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  auto push_forward_fn0
-      = element0->basix_element().map_fn<u_t, U_t, J_t, K_t>();
+  auto push_forward_fn0 = e0->basix_element().map_fn<u_t, U_t, J_t, K_t>();
 
   // Basis values of Lagrange space unrolled for block size
   // (num_quadrature_points, Lagrange dof, value_size)
-  xt::xtensor<double, 3> basis_values = xt::zeros<double>(
-      {X.shape(0), bs0 * dim0, (std::size_t)element1->value_size()});
-  xt::xtensor<double, 3> mapped_values(
-      {X.shape(0), bs0 * dim0, (std::size_t)element1->value_size()});
+  std::vector<double> basis_values_b(Xshape[0] * bs0 * dim0 * e1->value_size());
+  mdspan3_t basis_values(basis_values_b.data(), Xshape[0], bs0 * dim0,
+                         e1->value_size());
+  std::vector<double> mapped_values_b(Xshape[0] * bs0 * dim0
+                                      * e1->value_size());
+  mdspan3_t mapped_values(mapped_values_b.data(), Xshape[0], bs0 * dim0,
+                          e1->value_size());
 
-  auto pull_back_fn1 = element1->basix_element().map_fn<u_t, U_t, K_t, J_t>();
+  auto pull_back_fn1 = e1->basix_element().map_fn<u_t, U_t, K_t, J_t>();
 
-  xt::xtensor<double, 2> coordinate_dofs({num_dofs_g, 3});
-  xt::xtensor<double, 3> basis0({X.shape(0), dim0, value_size0});
-  std::vector<T> A(space_dim0 * space_dim1);
+  std::vector<double> coord_dofs_b(num_dofs_g * gdim);
+  mdspan2_t coord_dofs(coord_dofs_b.data(), num_dofs_g, gdim);
+  std::vector<double> basis0_b(Xshape[0] * dim0 * value_size0);
+  mdspan3_t basis0(basis0_b.data(), Xshape[0], dim0, value_size0);
+
+  // Buffers
+  std::vector<T> Ab(space_dim0 * space_dim1);
   std::vector<T> local1(space_dim1);
-
-  std::vector<std::size_t> shape
-      = {X.shape(0), (std::size_t)element1->value_size(), space_dim0};
-  auto _A = xt::adapt(A, shape);
 
   // Iterate over mesh and interpolate on each cell
   auto cell_map = mesh->topology().index_map(tdim);
   assert(cell_map);
   std::int32_t num_cells = cell_map->size_local();
-  auto _coordinate_dofs
-      = xt::view(coordinate_dofs, xt::all(), xt::xrange(0, gdim));
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
     // Get cell geometry (coordinate dofs)
     auto x_dofs = x_dofmap.links(c);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
-      common::impl::copy_N<3>(std::next(x_g.begin(), 3 * x_dofs[i]),
-                              std::next(coordinate_dofs.begin(), 3 * i));
+      for (std::size_t j = 0; j < gdim; ++j)
+        coord_dofs(i, j) = x_g[3 * x_dofs[i] + j];
     }
 
     // Compute Jacobians and reference points for current cell
-    J.fill(0);
-    for (std::size_t p = 0; p < X.shape(0); ++p)
+    std::fill(J_b.begin(), J_b.end(), 0);
+    for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
-      auto _J = xt::view(J, p, xt::all(), xt::all());
-      cmap.compute_jacobian(dphi, _coordinate_dofs, _J);
-      cmap.compute_jacobian_inverse(_J, xt::view(K, p, xt::all(), xt::all()));
-      detJ[p] = cmap.compute_jacobian_determinant(_J);
+      auto _J = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
+      cmap.compute_jacobian(dphi, coord_dofs, _J);
+      auto _K = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);
+      cmap.compute_jacobian_inverse(_J, _K);
+      detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
     }
 
-    // Get evaluated basis on reference, apply DOF transformations, and
+    // Copy evaluated basis on reference, apply DOF transformations, and
     // push forward to physical element
-    basis_reference0 = xt::view(basis_derivatives_reference0, 0, xt::all(),
-                                xt::all(), xt::all());
-    for (std::size_t p = 0; p < X.shape(0); ++p)
+    for (std::size_t k0 = 0; k0 < basis_reference0.extent(0); ++k0)
+      for (std::size_t k1 = 0; k1 < basis_reference0.extent(1); ++k1)
+        for (std::size_t k2 = 0; k2 < basis_reference0.extent(2); ++k2)
+          basis_reference0(k0, k1, k2)
+              = basis_derivatives_reference0(0, k0, k1, k2);
+    for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       apply_dof_transformation0(
-          xtl::span(basis_reference0.data() + p * dim0 * value_size_ref0,
+          std::span(basis_reference0.data_handle() + p * dim0 * value_size_ref0,
                     dim0 * value_size_ref0),
           cell_info, c, value_size_ref0);
     }
 
-    for (std::size_t i = 0; i < basis0.shape(0); ++i)
+    for (std::size_t p = 0; p < basis0.extent(0); ++p)
     {
-      u_t _u(basis0.data() + i * basis0.shape(1) * basis0.shape(2),
-             basis0.shape(1), basis0.shape(2));
-      U_t _U(basis_reference0.data()
-                 + i * basis_reference0.shape(1) * basis_reference0.shape(2),
-             basis_reference0.shape(1), basis_reference0.shape(2));
-      K_t _K(K.data() + i * K.shape(1) * K.shape(2), K.shape(1), K.shape(2));
-      J_t _J(J.data() + i * J.shape(1) * J.shape(2), J.shape(1), J.shape(2));
-      push_forward_fn0(_u, _U, _J, detJ[i], _K);
+      auto _u
+          = stdex::submdspan(basis0, p, stdex::full_extent, stdex::full_extent);
+      auto _U = stdex::submdspan(basis_reference0, p, stdex::full_extent,
+                                 stdex::full_extent);
+      auto _K = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);
+      auto _J = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
+      push_forward_fn0(_u, _U, _J, detJ[p], _K);
     }
 
     // Unroll basis function for input space for block size
-    for (std::size_t p = 0; p < X.shape(0); ++p)
+    for (std::size_t p = 0; p < Xshape[0]; ++p)
       for (std::size_t i = 0; i < dim0; ++i)
         for (std::size_t j = 0; j < value_size0; ++j)
           for (int k = 0; k < bs0; ++k)
             basis_values(p, i * bs0 + k, j * bs0 + k) = basis0(p, i, j);
 
     // Pull back the physical values to the reference of output space
-    for (std::size_t p = 0; p < basis_values.shape(0); ++p)
+    for (std::size_t p = 0; p < basis_values.extent(0); ++p)
     {
-      U_t _u(basis_values.data()
-                 + p * basis_values.shape(1) * basis_values.shape(2),
-             basis_values.shape(1), basis_values.shape(2));
-      u_t _U(mapped_values.data()
-                 + p * mapped_values.shape(1) * mapped_values.shape(2),
-             mapped_values.shape(1), mapped_values.shape(2));
-      K_t _K(K.data() + p * K.shape(1) * K.shape(2), K.shape(1), K.shape(2));
-      J_t _J(J.data() + p * J.shape(1) * J.shape(2), J.shape(1), J.shape(2));
+      auto _u = stdex::submdspan(basis_values, p, stdex::full_extent,
+                                 stdex::full_extent);
+      auto _U = stdex::submdspan(mapped_values, p, stdex::full_extent,
+                                 stdex::full_extent);
+      auto _K = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);
+      auto _J = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
       pull_back_fn1(_U, _u, _K, 1.0 / detJ[p], _J);
     }
 
     // Apply interpolation matrix to basis values of V0 at the
     // interpolation points of V1
     if (interpolation_ident)
-      _A.assign(xt::transpose(mapped_values, {0, 2, 1}));
+    {
+      stdex::mdspan<T, stdex::dextents<std::size_t, 3>> A(
+          Ab.data(), Xshape[0], e1->value_size(), space_dim0);
+      for (std::size_t i = 0; i < mapped_values.extent(0); ++i)
+        for (std::size_t j = 0; j < mapped_values.extent(1); ++j)
+          for (std::size_t k = 0; k < mapped_values.extent(2); ++k)
+            A(i, k, j) = mapped_values(i, j, k);
+    }
     else
     {
-      for (std::size_t i = 0; i < mapped_values.shape(1); ++i)
+      for (std::size_t i = 0; i < mapped_values.extent(1); ++i)
       {
-        auto _mapped_values = xt::view(mapped_values, xt::all(), i, xt::all());
-        impl::interpolation_apply(Pi_1, _mapped_values, local1, bs1);
+        auto values = stdex::submdspan(mapped_values, stdex::full_extent, i,
+                                       stdex::full_extent);
+        impl::interpolation_apply(Pi_1, values, std::span(local1), bs1);
         for (std::size_t j = 0; j < local1.size(); j++)
-          A[space_dim0 * j + i] = local1[j];
+          Ab[space_dim0 * j + i] = local1[j];
       }
     }
 
-    apply_inverse_dof_transform1(A, cell_info, c, space_dim0);
-    mat_set(dofmap1->cell_dofs(c), dofmap0->cell_dofs(c), A);
+    apply_inverse_dof_transform1(Ab, cell_info, c, space_dim0);
+    mat_set(dofmap1->cell_dofs(c), dofmap0->cell_dofs(c), Ab);
   }
 }
 

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -8,32 +8,41 @@
 #include "FiniteElement.h"
 #include "FunctionSpace.h"
 #include <dolfinx/mesh/Mesh.h>
-#include <xtensor/xbuilder.hpp>
 
 using namespace dolfinx;
 
 //-----------------------------------------------------------------------------
 std::vector<double>
 fem::interpolation_coords(const FiniteElement& element, const mesh::Mesh& mesh,
-                          const xtl::span<const std::int32_t>& cells)
+                          std::span<const std::int32_t> cells)
 {
   // Get mesh geometry data and the element coordinate map
   const std::size_t gdim = mesh.geometry().dim();
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
 
-  xtl::span<const double> x_g = mesh.geometry().x();
+  std::span<const double> x_g = mesh.geometry().x();
   const CoordinateElement& cmap = mesh.geometry().cmap();
   const std::size_t num_dofs_g = cmap.dim();
 
   // Get the interpolation points on the reference cells
-  const xt::xtensor<double, 2>& X = element.interpolation_points();
-  const xt::xtensor<double, 2> phi
-      = xt::view(cmap.tabulate(0, X), 0, xt::all(), xt::all(), 0);
+  const auto [X, Xshape] = element.interpolation_points();
+
+  // Evaluate coordinate element basis at reference points
+  namespace stdex = std::experimental;
+  using cmdspan4_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  std::array<std::size_t, 4> phi_shape = cmap.tabulate_shape(0, Xshape[0]);
+  std::vector<double> phi_b(
+      std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+  cmdspan4_t phi_full(phi_b.data(), phi_shape);
+  cmap.tabulate(0, X, Xshape, phi_b);
+  auto phi = stdex::submdspan(phi_full, 0, stdex::full_extent,
+                              stdex::full_extent, 0);
 
   // Push reference coordinates (X) forward to the physical coordinates
   // (x) for each cell
   std::vector<double> coordinate_dofs(num_dofs_g * gdim, 0);
-  std::vector<double> x(3 * (cells.size() * X.shape(0)), 0);
+  std::vector<double> x(3 * (cells.size() * Xshape[0]), 0);
   for (std::size_t c = 0; c < cells.size(); ++c)
   {
     // Get geometry data for current cell
@@ -45,14 +54,14 @@ fem::interpolation_coords(const FiniteElement& element, const mesh::Mesh& mesh,
     }
 
     // Push forward coordinates (X -> x)
-    for (std::size_t p = 0; p < X.shape(0); ++p)
+    for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       for (std::size_t j = 0; j < gdim; ++j)
       {
         double acc = 0;
         for (std::size_t k = 0; k < num_dofs_g; ++k)
           acc += phi(p, k) * coordinate_dofs[k * gdim + j];
-        x[j * (cells.size() * X.shape(0)) + c * X.shape(0) + p] = acc;
+        x[j * (cells.size() * Xshape[0]) + c * Xshape[0] + p] = acc;
       }
     }
   }

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -40,7 +40,7 @@ std::vector<double> interpolation_coords(const fem::FiniteElement& element,
                                          std::span<const std::int32_t> cells);
 namespace impl
 {
-/// @brief Scatter data into potentially non-contiguous memory
+/// @brief Scatter data into non-contiguous memory
 ///
 /// Scatter blocked data `send_values` to its
 /// corresponding src_rank and insert the data into `recv_values`.
@@ -56,7 +56,7 @@ namespace impl
 /// (src_ranks.size(), block_size). Storage is row-major.
 /// @param[in] s_shape Shape of send_values
 /// @param[in,out] recv_values Array to fill with values  Shape
-/// (dest_ranks.size(), s_shape[1]). Storage is row-major.
+/// (dest_ranks.size(), block_size). Storage is row-major.
 /// @pre It is required that src_ranks are sorted.
 /// @note dest_ranks can contain repeated entries
 /// @note dest_ranks might contain -1 (no process owns the point)

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -20,6 +20,26 @@
 #include <span>
 #include <vector>
 
+namespace dolfinx::fem
+{
+template <typename T>
+class Function;
+
+/// Compute the evaluation points in the physical space at which an
+/// expression should be computed to interpolate it in a finite element
+/// space.
+///
+/// @param[in] element The element to be interpolated into
+/// @param[in] mesh The domain
+/// @param[in] cells Indices of the cells in the mesh to compute
+/// interpolation coordinates for
+/// @return The coordinates in the physical space at which to evaluate
+/// an expression. The shape is (3, num_points) and storage is row-major.
+std::vector<double>
+interpolation_coords(const fem::FiniteElement& element, const mesh::Mesh& mesh,
+                     std::span<const std::int32_t> cells);
+}
+
 namespace
 {
 
@@ -162,20 +182,6 @@ namespace dolfinx::fem
 template <typename T>
 class Function;
 
-/// Compute the evaluation points in the physical space at which an
-/// expression should be computed to interpolate it in a finite element
-/// space.
-///
-/// @param[in] element The element to be interpolated into
-/// @param[in] mesh The domain
-/// @param[in] cells Indices of the cells in the mesh to compute
-/// interpolation coordinates for
-/// @return The coordinates in the physical space at which to evaluate
-/// an expression. The shape is (3, num_points) and storage is row-major.
-std::vector<double>
-interpolation_coords(const fem::FiniteElement& element, const mesh::Mesh& mesh,
-                     const xtl::span<const std::int32_t>& cells);
-
 /// Interpolate an expression f(x) in a finite element space
 ///
 /// @param[out] u The function to interpolate into
@@ -189,7 +195,7 @@ interpolation_coords(const fem::FiniteElement& element, const mesh::Mesh& mesh,
 /// fem::interpolation_coords.
 template <typename T>
 void interpolate(Function<T>& u, const xt::xarray<T>& f,
-                 const xtl::span<const std::int32_t>& cells);
+                 const std::span<const std::int32_t>& cells);
 
 namespace impl
 {
@@ -567,7 +573,7 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
 /// @param[in] cells List of cell indices to interpolate on
 template <typename T>
 void interpolate_nonmatching_meshes(Function<T>& u, const Function<T>& v,
-                                    const xtl::span<const std::int32_t>& cells)
+                                    std::span<const std::int32_t> cells)
 {
   assert(u.function_space());
   assert(v.function_space());
@@ -646,20 +652,6 @@ void interpolate_nonmatching_meshes(Function<T>& u, const Function<T>& v,
 }
 
 } // namespace impl
-
-/// Compute the evaluation points in the physical space at which an
-/// expression should be computed to interpolate it in a finite element
-/// space.
-///
-/// @param[in] element The element to be interpolated into
-/// @param[in] mesh The domain
-/// @param[in] cells Indices of the cells in the mesh to compute
-/// interpolation coordinates for
-/// @return The coordinates in the physical space at which to evaluate
-/// an expression. The shape is (3, num_points) and storage is row-major.
-std::vector<double> interpolation_coords(const FiniteElement& element,
-                                         const mesh::Mesh& mesh,
-                                         std::span<const std::int32_t> cells);
 
 /// Interpolate an expression f(x) in a finite element space
 ///
@@ -958,7 +950,7 @@ template <typename T>
 void interpolate(
     Function<T>& u,
     const std::function<xt::xarray<T>(const xt::xtensor<double, 2>&)>& f,
-    const xt::xtensor<double, 2>& x, const xtl::span<const std::int32_t>& cells)
+    const xt::xtensor<double, 2>& x, const std::span<const std::int32_t>& cells)
 {
   // Evaluate function at physical points. The returned array has a
   // number of rows equal to the number of components of the function,

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -568,7 +568,7 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
 }
 //----------------------------------------------------------------------------
 /// Interpolate from one finite element Function to another
-/// @param[out] u The function to interpolate into
+/// @param[in,out] u The function to interpolate into
 /// @param[in] v The function to be interpolated
 /// @param[in] cells List of cell indices to interpolate on
 template <typename T>
@@ -966,7 +966,7 @@ void interpolate(
 /// @param[in] cells List of cell indices to interpolate on
 template <typename T>
 void interpolate(Function<T>& u, const Function<T>& v,
-                 const std::span<const std::int32_t>& cells)
+                std::span<const std::int32_t> cells)
 {
   assert(u.function_space());
   assert(v.function_space());

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -389,8 +389,6 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi(phi_b.data(), phi_shape);
   cmap.tabulate(1, X, Xshape, phi_b);
-  auto dphi
-      = stdex::submdspan(phi, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
 
   // Evaluate v basis functions at reference interpolation points
   const auto [_basis_derivatives_reference0, b0shape]
@@ -455,14 +453,13 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
         coord_dofs(i, j) = x_g[pos + j];
     }
 
-    // TODO: the below has a bug for non-affine cells - the geometry
-    // basis should be evaluated at every point. See
-    // https://github.com/FEniCS/dolfinx/issues/2275.
-
     // Compute Jacobians and reference points for current cell
     std::fill(J_b.begin(), J_b.end(), 0);
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
+      auto dphi = stdex::submdspan(phi, std::pair(1, tdim + 1), p,
+                                   stdex::full_extent, 0);
+
       auto _J = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
       cmap.compute_jacobian(dphi, coord_dofs, _J);
       auto _K = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -17,12 +17,8 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <functional>
 #include <numeric>
+#include <span>
 #include <vector>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
-#include <xtl/xspan.hpp>
 
 namespace
 {
@@ -32,31 +28,33 @@ namespace
 ///
 /// The data to send is structured as (src_ranks.size(), value_size), where the
 /// ith row of `send_data` is sent to the process with rank `src_ranks[i]`. The
-/// ranks are using the ranks of the input communicator `comm`. `src_ranks` and
-/// `send_values` are assumed to be sorted, meaning that it is ordered by
-/// process to receive data. `dest_ranks` is a list of ranks the current process
-/// is receiving data from. This function returns a 2D array of shape
-/// (dest_ranks.size(), value_size). If the j-th dest rank is -1, then
-/// row(output,j) = (0,)*value_size.
+/// ranks are using the ranks of the input communicator `comm`.
+// If the j-th dest rank is -1, then
+// `recv_values[j*value_size:(j+1)*value_size]) = 0.
 ///
 /// @param[in] comm The mpi communicator
 /// @param[in] src_ranks The rank owning the values of each row in send_values
 /// @note It is assumed that src_ranks are already sorted.
-/// @param[in] dest_ranks The rank each local point is receiving data from.
+/// @param[in] dest_ranks List of ranks receiving data. Size of array is how
+/// many values we are receiving (not unrolled for value_size).
+/// @note dest_ranks can contain repeated entries
 /// @note dest_ranks might contain -1 (no process owns the point)
 /// @param[in] send_values The values to send back to owner. Shape
-/// (src_ranks.size(), value_size).
-/// @returns An 2D array of shape (dest_ranks.size(), value_size) with values
-/// from the process owning the local point.
+/// (src_ranks.size(), value_size). Storage is row-major.
+/// @param[in] s_shape Shape of send_values
+/// @param[in,out] recv_values Array to fill with values  Shape
+/// (dest_ranks.size(), s_shape[1]). Storage is row-major.
 template <typename T>
-xt::xtensor<T, 2> send_back_values(const MPI_Comm& comm,
-                                   const std::vector<std::int32_t>& src_ranks,
-                                   const std::vector<std::int32_t>& dest_ranks,
-                                   const xt::xtensor<T, 2> send_values)
+void send_back_values(const MPI_Comm& comm,
+                      const std::vector<std::int32_t>& src_ranks,
+                      const std::vector<std::int32_t>& dest_ranks,
+                      std::span<const T> send_values,
+                      const std::array<std::size_t, 2>& s_shape,
+                      std::span<T> recv_values)
 {
-  assert(src_ranks.size() == send_values.shape(0));
-  const std::size_t value_size = send_values.shape(1);
-  xt::xtensor<T, 2> values({dest_ranks.size(), value_size});
+  const std::size_t value_size = s_shape[1];
+  assert(src_ranks.size() * value_size == send_values.size());
+  assert(recv_values.size() == dest_ranks.size() * value_size);
 
   // Create neighborhood communicator from send back
   // values to requesting processes
@@ -138,24 +136,23 @@ xt::xtensor<T, 2> send_back_values(const MPI_Comm& comm,
                    std::next(send_offsets.begin(), 1));
 
   // Send values back to interpolating mesh
-  std::vector<T> recv_values(recv_offsets.back());
-  recv_values.reserve(recv_values.size() + 1);
+  std::vector<T> values(recv_offsets.back());
+  values.reserve(values.size() + 1);
 
-  MPI_Neighbor_alltoallv(
-      send_values.data(), send_sizes.data(), send_offsets.data(),
-      dolfinx::MPI::mpi_type<T>(), recv_values.data(), recv_sizes.data(),
-      recv_offsets.data(), dolfinx::MPI::mpi_type<T>(), reverse_comm);
+  MPI_Neighbor_alltoallv(send_values.data(), send_sizes.data(),
+                         send_offsets.data(), dolfinx::MPI::mpi_type<T>(),
+                         values.data(), recv_sizes.data(), recv_offsets.data(),
+                         dolfinx::MPI::mpi_type<T>(), reverse_comm);
   MPI_Comm_free(&reverse_comm);
 
   // Fill in values for interpolation points on local process
-  std::fill(values.begin(), values.end(), T(0));
+  std::fill(recv_values.begin(), recv_values.end(), T(0));
   for (std::size_t i = 0; i < unpack_map.size(); i++)
   {
-    auto vals = std::next(values.begin(), unpack_map[i] * value_size);
-    auto vals_from = std::next(recv_values.begin(), i * value_size);
+    auto vals = std::next(recv_values.begin(), unpack_map[i] * value_size);
+    auto vals_from = std::next(values.begin(), i * value_size);
     std::copy_n(vals_from, value_size, vals);
   }
-  return values;
 };
 
 } // namespace
@@ -196,7 +193,7 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
 
 namespace impl
 {
-/// Apply interpolation operator Pi to data to evaluate the dof
+/// @brief Apply interpolation operator Pi to data to evaluate the dof
 /// coefficients
 /// @param[in] Pi The interpolation matrix (shape = (num dofs,
 /// num_points * value_size))
@@ -205,29 +202,32 @@ namespace impl
 /// @param[out] coeffs The degrees of freedom to compute
 /// @param[in] bs The block size
 template <typename U, typename V, typename T>
-void interpolation_apply(const U& Pi, const V& data, std::vector<T>& coeffs,
+void interpolation_apply(const U& Pi, const V& data, std::span<T> coeffs,
                          int bs)
 {
+  static_assert(U::rank() == 2, "Must be rank 2");
+  static_assert(V::rank() == 2, "Must be rank 2");
+
   // Compute coefficients = Pi * x (matrix-vector multiply)
   if (bs == 1)
   {
-    assert(data.shape(0) * data.shape(1) == Pi.shape(1));
-    for (std::size_t i = 0; i < Pi.shape(0); ++i)
+    assert(data.extent(0) * data.extent(1) == Pi.extent(1));
+    for (std::size_t i = 0; i < Pi.extent(0); ++i)
     {
       coeffs[i] = 0.0;
-      for (std::size_t k = 0; k < data.shape(1); ++k)
-        for (std::size_t j = 0; j < data.shape(0); ++j)
-          coeffs[i] += Pi(i, k * data.shape(0) + j) * data(j, k);
+      for (std::size_t k = 0; k < data.extent(1); ++k)
+        for (std::size_t j = 0; j < data.extent(0); ++j)
+          coeffs[i] += Pi(i, k * data.extent(0) + j) * data(j, k);
     }
   }
   else
   {
-    const std::size_t cols = Pi.shape(1);
-    assert(data.shape(0) == Pi.shape(1));
-    assert(data.shape(1) == bs);
+    const std::size_t cols = Pi.extent(1);
+    assert(data.extent(0) == Pi.extent(1));
+    assert(data.extent(1) == bs);
     for (int k = 0; k < bs; ++k)
     {
-      for (std::size_t i = 0; i < Pi.shape(0); ++i)
+      for (std::size_t i = 0; i < Pi.extent(0); ++i)
       {
         T acc = 0;
         for (std::size_t j = 0; j < cols; ++j)
@@ -250,7 +250,7 @@ void interpolation_apply(const U& Pi, const V& data, std::vector<T>& coeffs,
 /// by the function.
 template <typename T>
 void interpolate_same_map(Function<T>& u1, const Function<T>& u0,
-                          const xtl::span<const std::int32_t>& cells)
+                          std::span<const std::int32_t> cells)
 {
   auto V0 = u0.function_space();
   assert(V0);
@@ -267,24 +267,20 @@ void interpolate_same_map(Function<T>& u1, const Function<T>& u0,
   const int tdim = mesh->topology().dim();
   auto map = mesh->topology().index_map(tdim);
   assert(map);
-  xtl::span<T> u1_array = u1.x()->mutable_array();
-  xtl::span<const T> u0_array = u0.x()->array();
+  std::span<T> u1_array = u1.x()->mutable_array();
+  std::span<const T> u0_array = u0.x()->array();
 
-  xtl::span<const std::uint32_t> cell_info;
+  std::span<const std::uint32_t> cell_info;
   if (element1->needs_dof_transformations()
       or element0->needs_dof_transformations())
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
 
   // Get dofmaps
   auto dofmap1 = V1->dofmap();
   auto dofmap0 = V0->dofmap();
-
-  // Create interpolation operator
-  const xt::xtensor<double, 2> i_m
-      = element1->create_interpolation_operator(*element0);
 
   // Get block sizes and dof transformation operators
   const int bs1 = dofmap1->bs();
@@ -298,10 +294,14 @@ void interpolate_same_map(Function<T>& u1, const Function<T>& u0,
   std::vector<T> local0(element0->space_dimension());
   std::vector<T> local1(element1->space_dimension());
 
+  // Create interpolation operator
+  const auto [i_m, im_shape]
+      = element1->create_interpolation_operator(*element0);
+
   // Iterate over mesh and interpolate on each cell
   for (auto c : cells)
   {
-    xtl::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
+    std::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
     for (std::size_t i = 0; i < dofs0.size(); ++i)
       for (int k = 0; k < bs0; ++k)
         local0[bs0 * i + k] = u0_array[bs0 * dofs0[i] + k];
@@ -311,13 +311,13 @@ void interpolate_same_map(Function<T>& u1, const Function<T>& u0,
     // FIXME: Get compile-time ranges from Basix
     // Apply interpolation operator
     std::fill(local1.begin(), local1.end(), 0);
-    for (std::size_t i = 0; i < i_m.shape(0); ++i)
-      for (std::size_t j = 0; j < i_m.shape(1); ++j)
-        local1[i] += i_m(i, j) * local0[j];
+    for (std::size_t i = 0; i < im_shape[0]; ++i)
+      for (std::size_t j = 0; j < im_shape[1]; ++j)
+        local1[i] += i_m[im_shape[1] * i + j] * local0[j];
 
     apply_inverse_dof_transform(local1, cell_info, c, 1);
 
-    xtl::span<const std::int32_t> dofs1 = dofmap1->cell_dofs(c);
+    std::span<const std::int32_t> dofs1 = dofmap1->cell_dofs(c);
     for (std::size_t i = 0; i < dofs1.size(); ++i)
       for (int k = 0; k < bs1; ++k)
         u1_array[bs1 * dofs1[i] + k] = local1[bs1 * i + k];
@@ -335,7 +335,7 @@ void interpolate_same_map(Function<T>& u1, const Function<T>& u0,
 /// not checked by the function.
 template <typename T>
 void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
-                                  const xtl::span<const std::int32_t>& cells)
+                                  std::span<const std::int32_t> cells)
 {
   // Get mesh
   auto V0 = u0.function_space();
@@ -355,19 +355,19 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
   std::shared_ptr<const FiniteElement> element1 = V1->element();
   assert(element1);
 
-  xtl::span<const std::uint32_t> cell_info;
+  std::span<const std::uint32_t> cell_info;
   if (element1->needs_dof_transformations()
       or element0->needs_dof_transformations())
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
 
   // Get dofmaps
   auto dofmap0 = V0->dofmap();
   auto dofmap1 = V1->dofmap();
 
-  const xt::xtensor<double, 2> X = element1->interpolation_points();
+  const auto [X, Xshape] = element1->interpolation_points();
 
   // Get block sizes and dof transformation operators
   const int bs0 = element0->block_size();
@@ -387,34 +387,65 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
   const graph::AdjacencyList<std::int32_t>& x_dofmap
       = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
-  xtl::span<const double> x_g = mesh->geometry().x();
+  std::span<const double> x_g = mesh->geometry().x();
+
+  namespace stdex = std::experimental;
+  using cmdspan2_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan4_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
+  using mdspan3T_t = stdex::mdspan<T, stdex::dextents<std::size_t, 3>>;
 
   // Evaluate coordinate map basis at reference interpolation points
-  xt::xtensor<double, 4> phi(cmap.tabulate_shape(1, X.shape(0)));
-  xt::xtensor<double, 2> dphi;
-  cmap.tabulate(1, X, phi);
-  dphi = xt::view(phi, xt::range(1, tdim + 1), 0, xt::all(), 0);
+  const std::array<std::size_t, 4> phi_shape
+      = cmap.tabulate_shape(1, Xshape[0]);
+  std::vector<double> phi_b(
+      std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+  cmdspan4_t phi(phi_b.data(), phi_shape);
+  cmap.tabulate(1, X, Xshape, phi_b);
+  auto dphi
+      = stdex::submdspan(phi, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
 
   // Evaluate v basis functions at reference interpolation points
-  const xt::xtensor<double, 4> basis_derivatives_reference0
-      = element0->tabulate(X, 0);
+  const auto [_basis_derivatives_reference0, b0shape]
+      = element0->tabulate(X, Xshape, 0);
+  cmdspan4_t basis_derivatives_reference0(_basis_derivatives_reference0.data(),
+                                          b0shape);
 
   // Create working arrays
   std::vector<T> local1(element1->space_dimension());
   std::vector<T> coeffs0(element0->space_dimension());
-  xt::xtensor<double, 3> basis0({X.shape(0), dim0, value_size0});
-  xt::xtensor<double, 3> basis_reference0({X.shape(0), dim0, value_size_ref0});
-  xt::xtensor<T, 3> values0({X.shape(0), 1, element1->value_size()});
-  xt::xtensor<T, 3> mapped_values0({X.shape(0), 1, element1->value_size()});
-  xt::xtensor<double, 2> coordinate_dofs({num_dofs_g, gdim});
-  xt::xtensor<double, 3> J({X.shape(0), gdim, tdim});
-  xt::xtensor<double, 3> K({X.shape(0), tdim, gdim});
-  std::vector<double> detJ(X.shape(0));
+
+  std::vector<double> basis0_b(Xshape[0] * dim0 * value_size0);
+  mdspan3_t basis0(basis0_b.data(), Xshape[0], dim0, value_size0);
+
+  std::vector<double> basis_reference0_b(Xshape[0] * dim0 * value_size_ref0);
+  mdspan3_t basis_reference0(basis_reference0_b.data(), Xshape[0], dim0,
+                             value_size_ref0);
+
+  std::vector<T> values0_b(Xshape[0] * 1 * element1->value_size());
+  mdspan3T_t values0(values0_b.data(), Xshape[0], 1, element1->value_size());
+
+  std::vector<T> mapped_values_b(Xshape[0] * 1 * element1->value_size());
+  mdspan3T_t mapped_values0(mapped_values_b.data(), Xshape[0], 1,
+                            element1->value_size());
+
+  std::vector<double> coord_dofs_b(num_dofs_g * gdim);
+  mdspan2_t coord_dofs(coord_dofs_b.data(), num_dofs_g, gdim);
+
+  std::vector<double> J_b(Xshape[0] * gdim * tdim);
+  mdspan3_t J(J_b.data(), Xshape[0], gdim, tdim);
+  std::vector<double> K_b(Xshape[0] * tdim * gdim);
+  mdspan3_t K(K_b.data(), Xshape[0], tdim, gdim);
+  std::vector<double> detJ(Xshape[0]);
+  std::vector<double> det_scratch(2 * gdim * tdim);
 
   // Get interpolation operator
-  const xt::xtensor<double, 2> Pi_1 = element1->interpolation_operator();
+  const auto [_Pi_1, pi_shape] = element1->interpolation_operator();
+  cmdspan2_t Pi_1(_Pi_1.data(), pi_shape);
 
-  namespace stdex = std::experimental;
   using u_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
   using U_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
   using J_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
@@ -427,8 +458,8 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
   auto pull_back_fn1 = element1->basix_element().map_fn<V_t, v_t, K_t, J_t>();
 
   // Iterate over mesh and interpolate on each cell
-  xtl::span<const T> array0 = u0.x()->array();
-  xtl::span<T> array1 = u1.x()->mutable_array();
+  std::span<const T> array0 = u0.x()->array();
+  std::span<T> array1 = u1.x()->mutable_array();
   for (auto c : cells)
   {
     // Get cell geometry (coordinate dofs)
@@ -437,56 +468,60 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
     {
       const int pos = 3 * x_dofs[i];
       for (std::size_t j = 0; j < gdim; ++j)
-        coordinate_dofs(i, j) = x_g[pos + j];
+        coord_dofs(i, j) = x_g[pos + j];
     }
+
+    // TODO: the below has a bug for non-affine cells - the geometry
+    // basis should be evaluated at every point. See
+    // https://github.com/FEniCS/dolfinx/issues/2275.
 
     // Compute Jacobians and reference points for current cell
-    J.fill(0);
-    for (std::size_t p = 0; p < X.shape(0); ++p)
+    std::fill(J_b.begin(), J_b.end(), 0);
+    for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
-      auto _J = xt::view(J, p, xt::all(), xt::all());
-      cmap.compute_jacobian(dphi, coordinate_dofs, _J);
-      cmap.compute_jacobian_inverse(_J, xt::view(K, p, xt::all(), xt::all()));
-      detJ[p] = cmap.compute_jacobian_determinant(_J);
+      auto _J = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
+      cmap.compute_jacobian(dphi, coord_dofs, _J);
+      auto _K = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);
+      cmap.compute_jacobian_inverse(_J, _K);
+      detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
     }
 
-    // Get evaluated basis on reference, apply DOF transformations, and
+    // Copy evaluated basis on reference, apply DOF transformations, and
     // push forward to physical element
-    for (std::size_t k0 = 0; k0 < basis_reference0.shape(0); ++k0)
-      for (std::size_t k1 = 0; k1 < basis_reference0.shape(1); ++k1)
-        for (std::size_t k2 = 0; k2 < basis_reference0.shape(2); ++k2)
+    for (std::size_t k0 = 0; k0 < basis_reference0.extent(0); ++k0)
+      for (std::size_t k1 = 0; k1 < basis_reference0.extent(1); ++k1)
+        for (std::size_t k2 = 0; k2 < basis_reference0.extent(2); ++k2)
           basis_reference0(k0, k1, k2)
               = basis_derivatives_reference0(0, k0, k1, k2);
 
-    for (std::size_t p = 0; p < X.shape(0); ++p)
+    for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       apply_dof_transformation0(
-          xtl::span(basis_reference0.data() + p * dim0 * value_size_ref0,
+          std::span(basis_reference0_b.data() + p * dim0 * value_size_ref0,
                     dim0 * value_size_ref0),
           cell_info, c, value_size_ref0);
     }
 
-    for (std::size_t i = 0; i < basis0.shape(0); ++i)
+    for (std::size_t i = 0; i < basis0.extent(0); ++i)
     {
-      u_t _u(basis0.data() + i * basis0.shape(1) * basis0.shape(2),
-             basis0.shape(1), basis0.shape(2));
-      U_t _U(basis_reference0.data()
-                 + i * basis_reference0.shape(1) * basis_reference0.shape(2),
-             basis_reference0.shape(1), basis_reference0.shape(2));
-      K_t _K(K.data() + i * K.shape(1) * K.shape(2), K.shape(1), K.shape(2));
-      J_t _J(J.data() + i * J.shape(1) * J.shape(2), J.shape(1), J.shape(2));
+      auto _u
+          = stdex::submdspan(basis0, i, stdex::full_extent, stdex::full_extent);
+      auto _U = stdex::submdspan(basis_reference0, i, stdex::full_extent,
+                                 stdex::full_extent);
+      auto _K = stdex::submdspan(K, i, stdex::full_extent, stdex::full_extent);
+      auto _J = stdex::submdspan(J, i, stdex::full_extent, stdex::full_extent);
       push_forward_fn0(_u, _U, _J, detJ[i], _K);
     }
 
     // Copy expansion coefficients for v into local array
     const int dof_bs0 = dofmap0->bs();
-    xtl::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
+    std::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
     for (std::size_t i = 0; i < dofs0.size(); ++i)
       for (int k = 0; k < dof_bs0; ++k)
         coeffs0[dof_bs0 * i + k] = array0[dof_bs0 * dofs0[i] + k];
 
     // Evaluate v at the interpolation points (physical space values)
-    for (std::size_t p = 0; p < X.shape(0); ++p)
+    for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       for (int k = 0; k < bs0; ++k)
       {
@@ -501,25 +536,25 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
     }
 
     // Pull back the physical values to the u reference
-    for (std::size_t i = 0; i < values0.shape(0); ++i)
+    for (std::size_t i = 0; i < values0.extent(0); ++i)
     {
-      v_t _v(values0.data() + i * values0.shape(1) * values0.shape(2),
-             values0.shape(1), values0.shape(2));
-      V_t _V(mapped_values0.data()
-                 + i * mapped_values0.shape(1) * mapped_values0.shape(2),
-             mapped_values0.shape(1), mapped_values0.shape(2));
-      K_t _K(K.data() + i * K.shape(1) * K.shape(2), K.shape(1), K.shape(2));
-      J_t _J(J.data() + i * J.shape(1) * J.shape(2), J.shape(1), J.shape(2));
-      pull_back_fn1(_V, _v, _K, 1.0 / detJ[i], _J);
+      auto _u = stdex::submdspan(values0, i, stdex::full_extent,
+                                 stdex::full_extent);
+      auto _U = stdex::submdspan(mapped_values0, i, stdex::full_extent,
+                                 stdex::full_extent);
+      auto _K = stdex::submdspan(K, i, stdex::full_extent, stdex::full_extent);
+      auto _J = stdex::submdspan(J, i, stdex::full_extent, stdex::full_extent);
+      pull_back_fn1(_U, _u, _K, 1.0 / detJ[i], _J);
     }
 
-    auto _mapped_values0 = xt::view(mapped_values0, xt::all(), 0, xt::all());
-    interpolation_apply(Pi_1, _mapped_values0, local1, bs1);
+    auto values = stdex::submdspan(mapped_values0, stdex::full_extent, 0,
+                                   stdex::full_extent);
+    interpolation_apply(Pi_1, values, std::span(local1), bs1);
     apply_inverse_dof_transform1(local1, cell_info, c, 1);
 
     // Copy local coefficients to the correct position in u dof array
     const int dof_bs1 = dofmap1->bs();
-    xtl::span<const std::int32_t> dofs1 = dofmap1->cell_dofs(c);
+    std::span<const std::int32_t> dofs1 = dofmap1->cell_dofs(c);
     for (std::size_t i = 0; i < dofs1.size(); ++i)
       for (int k = 0; k < dof_bs1; ++k)
         array1[dof_bs1 * dofs1[i] + k] = local1[dof_bs1 * i + k];
@@ -559,40 +594,98 @@ void interpolate_nonmatching_meshes(Function<T>& u, const Function<T>& v,
 
   // Collect all the points at which values are needed to define the
   // interpolating function
-  xt::xtensor<double, 2> x;
+  std::vector<double> x;
   {
-    const std::vector<double> coords
+    const std::vector<double> coords_b
         = fem::interpolation_coords(*element_u, *mesh, cells);
-    x = xt::transpose(
-        xt::adapt(coords, std::array<std::size_t, 2>{3, coords.size() / 3}));
+
+    namespace stdex = std::experimental;
+    using cmdspan2_t
+        = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+    using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+    cmdspan2_t coords(coords_b.data(), 3, coords_b.size() / 3);
+    // Transpose interpolation coords
+    x.resize(coords.size());
+    mdspan2_t _x(x.data(), coords_b.size() / 3, 3);
+    for (std::size_t i = 0; i < coords.extent(0); ++i)
+      for (std::size_t j = 0; j < 3; ++j)
+        _x(j, i) = coords(i, j);
   }
 
   // Determine ownership of each point
-  auto [dest_ranks, src_ranks, _points, evaluation_cells]
+  auto [dest_ranks, src_ranks, received_points, evaluation_cells]
       = dolfinx::geometry::determine_point_ownership(*mesh_v, x);
-  xt::xtensor<double, 2> received_points
-      = xt::adapt(_points, {_points.size() / 3, (std::size_t)3});
 
   // Evaluate the interpolating function where possible
-  xt::xtensor<T, 2> send_values
-      = xt::zeros<T>({received_points.shape(0), std::size_t(value_size)});
-  v.eval(received_points, evaluation_cells, send_values);
+  std::vector<T> send_values(received_points.size() / 3 * value_size);
+  v.eval(received_points, {received_points.size() / 3, (std::size_t)3},
+         evaluation_cells, send_values,
+         {received_points.size() / 3, (std::size_t)value_size});
 
   // Send values back to owning process
-  xt::xtensor<T, 2> values
-      = send_back_values(comm, src_ranks, dest_ranks, send_values);
+  std::array<std::size_t, 2> v_shape = {src_ranks.size(), value_size};
+  std::vector<T> values_b(dest_ranks.size() * value_size);
+  send_back_values(comm, src_ranks, dest_ranks, std::span<const T>(send_values),
+                   v_shape, std::span<T>(values_b));
+
+  // Transpose received data
+  namespace stdex = std::experimental;
+  stdex::mdspan<const T, stdex::dextents<std::size_t, 2>> values(
+      values_b.data(), dest_ranks.size(), value_size);
+
+  xt::xarray<T> valuesT_b({v_shape[1], v_shape[0]});
+  stdex::mdspan<T, stdex::dextents<std::size_t, 2>> valuesT(
+      valuesT_b.data(), values.extent(1), values.extent(0));
+
+  for (std::size_t i = 0; i < values.extent(0); ++i)
+    for (std::size_t j = 0; j < values.extent(1); ++j)
+      valuesT(j, i) = values(i, j);
 
   // Call local interpolation operator
-  xt::xarray<T> values_t = xt::transpose(values);
-  fem::interpolate(u, values_t, cells);
+  fem::interpolate(u, valuesT_b, cells);
 }
 
 } // namespace impl
 
+/// Compute the evaluation points in the physical space at which an
+/// expression should be computed to interpolate it in a finite element
+/// space.
+///
+/// @param[in] element The element to be interpolated into
+/// @param[in] mesh The domain
+/// @param[in] cells Indices of the cells in the mesh to compute
+/// interpolation coordinates for
+/// @return The coordinates in the physical space at which to evaluate
+/// an expression. The shape is (3, num_points) and storage is row-major.
+std::vector<double> interpolation_coords(const FiniteElement& element,
+                                         const mesh::Mesh& mesh,
+                                         std::span<const std::int32_t> cells);
+
+/// Interpolate an expression f(x) in a finite element space
+///
+/// @param[out] u The function to interpolate into
+/// @param[in] f Evaluation of the function `f(x)` at the physical
+/// points `x` given by fem::interpolation_coords. The element used in
+/// fem::interpolation_coords should be the same element as associated
+/// with `u`. The shape of `f` should be (value_size, num_points), with
+/// row-major storage.
+/// @param[in] fshape The shape of `f`.
+/// @param[in] cells Indices of the cells in the mesh on which to
+/// interpolate. Should be the same as the list used when calling
+/// fem::interpolation_coords.
 template <typename T>
-void interpolate(Function<T>& u, const xt::xarray<T>& f,
-                 const xtl::span<const std::int32_t>& cells)
+void interpolate(Function<T>& u, std::span<const T> f,
+                 std::array<std::size_t, 2> fshape,
+                 std::span<const std::int32_t> cells)
 {
+  namespace stdex = std::experimental;
+  using cmdspan2_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan4_t
+      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
+
   const std::shared_ptr<const FiniteElement> element
       = u.function_space()->element();
   assert(element);
@@ -604,6 +697,9 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
                              "Interpolate into subspaces.");
   }
 
+  if (fshape[0] != (std::size_t)element->value_size())
+    throw std::runtime_error("Interpolation data has the wrong shape/size.");
+
   // Get mesh
   assert(u.function_space());
   auto mesh = u.function_space()->mesh();
@@ -612,28 +708,15 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
   const int gdim = mesh->geometry().dim();
   const int tdim = mesh->topology().dim();
 
-  xtl::span<const std::uint32_t> cell_info;
+  std::span<const std::uint32_t> cell_info;
   if (element->needs_dof_transformations())
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
 
-  if (f.dimension() == 1)
-  {
-    if (element->value_size() != 1)
-      throw std::runtime_error("Interpolation data has the wrong shape/size.");
-  }
-  else if (f.dimension() == 2)
-  {
-    if (f.shape(0) != element->value_size())
-      throw std::runtime_error("Interpolation data has the wrong shape/size.");
-  }
-  else
-    throw std::runtime_error("Interpolation data has wrong shape.");
-
-  const xtl::span<const T> _f(f.data(), f.size());
-  const std::size_t f_shape1 = _f.size() / element->value_size();
+  const std::size_t f_shape1 = f.size() / element->value_size();
+  stdex::mdspan<const T, stdex::dextents<std::size_t, 2>> _f(f.data(), fshape);
 
   // Get dofmap
   const auto dofmap = u.function_space()->dofmap();
@@ -644,13 +727,16 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
   const int num_scalar_dofs = element->space_dimension() / element_bs;
   const int value_size = element->value_size() / element_bs;
 
-  xtl::span<T> coeffs = u.x()->mutable_array();
+  std::span<T> coeffs = u.x()->mutable_array();
   std::vector<T> _coeffs(num_scalar_dofs);
 
   // This assumes that any element with an identity interpolation matrix
   // is a point evaluation
   if (element->interpolation_ident())
   {
+    // Point evaluation element *and* the geometric map is the identity,
+    // e.g. not Piola mapped
+
     if (!element->map_ident())
       throw std::runtime_error("Element does not have identity map.");
 
@@ -661,12 +747,12 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
     for (std::size_t c = 0; c < cells.size(); ++c)
     {
       const std::int32_t cell = cells[c];
-      xtl::span<const std::int32_t> dofs = dofmap->cell_dofs(cell);
+      std::span<const std::int32_t> dofs = dofmap->cell_dofs(cell);
       for (int k = 0; k < element_bs; ++k)
       {
         // num_scalar_dofs is the number of interpolation points per
         // cell in this case (interpolation matrix is identity)
-        std::copy_n(std::next(_f.begin(), k * f_shape1 + c * num_scalar_dofs),
+        std::copy_n(std::next(f.begin(), k * f_shape1 + c * num_scalar_dofs),
                     num_scalar_dofs, _coeffs.begin());
         apply_inv_transpose_dof_transformation(_coeffs, cell_info, cell, 1);
         for (int i = 0; i < num_scalar_dofs; ++i)
@@ -680,30 +766,34 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
   }
   else if (element->map_ident())
   {
-    if (f.dimension() != 1)
+    // Not a point evaluation, but the geometric map is the identity,
+    // e.g. not Piola mapped
+
+    if (_f.extent(0) != 1)
       throw std::runtime_error("Interpolation data has the wrong shape.");
 
     // Get interpolation operator
-    const xt::xtensor<double, 2>& Pi = element->interpolation_operator();
-    const std::size_t num_interp_points = Pi.shape(1);
-    assert(Pi.shape(0) == num_scalar_dofs);
+    const auto [_Pi, pi_shape] = element->interpolation_operator();
+    cmdspan2_t Pi(_Pi.data(), pi_shape);
+    const std::size_t num_interp_points = Pi.extent(1);
+    assert(Pi.extent(0) == num_scalar_dofs);
 
     auto apply_inv_transpose_dof_transformation
         = element->get_dof_transformation_function<T>(true, true, true);
 
     // Loop over cells
-    xt::xtensor<T, 2> reference_data({num_interp_points, 1});
+    std::vector<T> ref_data_b(num_interp_points);
+    stdex::mdspan<T, stdex::extents<std::size_t, stdex::dynamic_extent, 1>>
+        ref_data(ref_data_b.data(), num_interp_points, 1);
     for (std::size_t c = 0; c < cells.size(); ++c)
     {
       const std::int32_t cell = cells[c];
-      xtl::span<const std::int32_t> dofs = dofmap->cell_dofs(cell);
+      std::span<const std::int32_t> dofs = dofmap->cell_dofs(cell);
       for (int k = 0; k < element_bs; ++k)
       {
-        std::copy_n(std::next(_f.begin(), k * f_shape1 + c * num_interp_points),
-                    num_interp_points, reference_data.begin());
-
-        impl::interpolation_apply(Pi, reference_data, _coeffs, element_bs);
-
+        std::copy_n(std::next(f.begin(), k * f_shape1 + c * num_interp_points),
+                    num_interp_points, ref_data_b.begin());
+        impl::interpolation_apply(Pi, ref_data, std::span(_coeffs), element_bs);
         apply_inv_transpose_dof_transformation(_coeffs, cell_info, cell, 1);
         for (int i = 0; i < num_scalar_dofs; ++i)
         {
@@ -717,14 +807,14 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
   else
   {
     // Get the interpolation points on the reference cells
-    const xt::xtensor<double, 2> X = element->interpolation_points();
-    if (X.shape(0) == 0)
+    const auto [X, Xshape] = element->interpolation_points();
+    if (X.empty())
     {
       throw std::runtime_error(
           "Interpolation into this space is not yet supported.");
     }
 
-    if (f.shape(1) != cells.size() * X.shape(0))
+    if (_f.extent(1) != cells.size() * Xshape[0])
       throw std::runtime_error("Interpolation data has the wrong shape.");
 
     // Get coordinate map
@@ -734,31 +824,46 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
     const graph::AdjacencyList<std::int32_t>& x_dofmap
         = mesh->geometry().dofmap();
     const int num_dofs_g = cmap.dim();
-    xtl::span<const double> x_g = mesh->geometry().x();
+    std::span<const double> x_g = mesh->geometry().x();
 
     // Create data structures for Jacobian info
-    xt::xtensor<double, 3> J = xt::empty<double>({int(X.shape(0)), gdim, tdim});
-    xt::xtensor<double, 3> K = xt::empty<double>({int(X.shape(0)), tdim, gdim});
-    xt::xtensor<double, 1> detJ = xt::empty<double>({X.shape(0)});
+    std::vector<double> J_b(Xshape[0] * gdim * tdim);
+    mdspan3_t J(J_b.data(), Xshape[0], gdim, tdim);
+    std::vector<double> K_b(Xshape[0] * tdim * gdim);
+    mdspan3_t K(K_b.data(), Xshape[0], tdim, gdim);
+    std::vector<double> detJ(Xshape[0]);
+    std::vector<double> det_scratch(2 * gdim * tdim);
 
-    xt::xtensor<double, 2> coordinate_dofs
-        = xt::empty<double>({num_dofs_g, gdim});
+    std::vector<double> coord_dofs_b(num_dofs_g * gdim);
+    mdspan2_t coord_dofs(coord_dofs_b.data(), num_dofs_g, gdim);
 
-    xt::xtensor<T, 3> reference_data({X.shape(0), 1, value_size});
-    xt::xtensor<T, 3> _vals({X.shape(0), 1, value_size});
+    std::vector<T> ref_data_b(Xshape[0] * 1 * value_size);
+    stdex::mdspan<T, stdex::dextents<std::size_t, 3>> ref_data(
+        ref_data_b.data(), Xshape[0], 1, value_size);
 
-    // Tabulate 1st order derivatives of shape functions at interpolation coords
-    xt::xtensor<double, 3> dphi = xt::view(
-        cmap.tabulate(1, X), xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
+    std::vector<T> _vals_b(Xshape[0] * 1 * value_size);
+    stdex::mdspan<T, stdex::dextents<std::size_t, 3>> _vals(
+        _vals_b.data(), Xshape[0], 1, value_size);
 
-    const std::function<void(const xtl::span<T>&,
-                             const xtl::span<const std::uint32_t>&,
+    // Tabulate 1st derivative of shape functions at interpolation
+    // coords
+    std::array<std::size_t, 4> phi_shape = cmap.tabulate_shape(1, Xshape[0]);
+    std::vector<double> phi_b(
+        std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+    cmdspan4_t phi(phi_b.data(), phi_shape);
+    cmap.tabulate(1, X, Xshape, phi_b);
+    auto dphi = stdex::submdspan(phi, std::pair(1, tdim + 1),
+                                 stdex::full_extent, stdex::full_extent, 0);
+
+    const std::function<void(const std::span<T>&,
+                             const std::span<const std::uint32_t>&,
                              std::int32_t, int)>
         apply_inverse_transpose_dof_transformation
         = element->get_dof_transformation_function<T>(true, true);
 
     // Get interpolation operator
-    const xt::xtensor<double, 2>& Pi = element->interpolation_operator();
+    const auto [_Pi, pi_shape] = element->interpolation_operator();
+    cmdspan2_t Pi(_Pi.data(), pi_shape);
 
     namespace stdex = std::experimental;
     using u_t = stdex::mdspan<const T, stdex::dextents<std::size_t, 2>>;
@@ -775,50 +880,54 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
       {
         const int pos = 3 * x_dofs[i];
         for (int j = 0; j < gdim; ++j)
-          coordinate_dofs(i, j) = x_g[pos + j];
+          coord_dofs(i, j) = x_g[pos + j];
       }
 
       // Compute J, detJ and K
-      J.fill(0);
-      for (std::size_t p = 0; p < X.shape(0); ++p)
+      std::fill(J_b.begin(), J_b.end(), 0);
+      for (std::size_t p = 0; p < Xshape[0]; ++p)
       {
-        cmap.compute_jacobian(xt::view(dphi, xt::all(), p, xt::all()),
-                              coordinate_dofs,
-                              xt::view(J, p, xt::all(), xt::all()));
-        cmap.compute_jacobian_inverse(xt::view(J, p, xt::all(), xt::all()),
-                                      xt::view(K, p, xt::all(), xt::all()));
-        detJ[p] = cmap.compute_jacobian_determinant(
-            xt::view(J, p, xt::all(), xt::all()));
+        auto _dphi
+            = stdex::submdspan(dphi, stdex::full_extent, p, stdex::full_extent);
+        auto _J
+            = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
+        cmap.compute_jacobian(_dphi, coord_dofs, _J);
+        auto _K
+            = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);
+        cmap.compute_jacobian_inverse(_J, _K);
+        detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
       }
 
-      xtl::span<const std::int32_t> dofs = dofmap->cell_dofs(cell);
+      std::span<const std::int32_t> dofs = dofmap->cell_dofs(cell);
       for (int k = 0; k < element_bs; ++k)
       {
         // Extract computed expression values for element block k
         for (int m = 0; m < value_size; ++m)
         {
-          std::copy_n(std::next(_f.begin(), f_shape1 * (k * value_size + m)
-                                                + c * X.shape(0)),
-                      X.shape(0), xt::view(_vals, xt::all(), 0, m).begin());
+          for (std::size_t k0 = 0; k0 < Xshape[0]; ++k0)
+          {
+            _vals(k0, 0, m)
+                = f[f_shape1 * (k * value_size + m) + c * Xshape[0] + k0];
+          }
         }
 
         // Get element degrees of freedom for block
-        for (std::size_t i = 0; i < X.shape(0); ++i)
+        for (std::size_t i = 0; i < Xshape[0]; ++i)
         {
-          u_t _u(_vals.data() + i * _vals.shape(1) * _vals.shape(2),
-                 _vals.shape(1), _vals.shape(2));
-          U_t _U(reference_data.data()
-                     + i * reference_data.shape(1) * reference_data.shape(2),
-                 reference_data.shape(1), reference_data.shape(2));
-          K_t _K(K.data() + i * K.shape(1) * K.shape(2), K.shape(1),
-                 K.shape(2));
-          J_t _J(J.data() + i * J.shape(1) * J.shape(2), J.shape(1),
-                 J.shape(2));
+          auto _u = stdex::submdspan(_vals, i, stdex::full_extent,
+                                     stdex::full_extent);
+          auto _U = stdex::submdspan(ref_data, i, stdex::full_extent,
+                                     stdex::full_extent);
+          auto _K
+              = stdex::submdspan(K, i, stdex::full_extent, stdex::full_extent);
+          auto _J
+              = stdex::submdspan(J, i, stdex::full_extent, stdex::full_extent);
           pull_back_fn(_U, _u, _K, 1.0 / detJ[i], _J);
         }
 
-        auto ref_data = xt::view(reference_data, xt::all(), 0, xt::all());
-        impl::interpolation_apply(Pi, ref_data, _coeffs, element_bs);
+        auto ref = stdex::submdspan(ref_data, stdex::full_extent, 0,
+                                    stdex::full_extent);
+        impl::interpolation_apply(Pi, ref, std::span(_coeffs), element_bs);
         apply_inverse_transpose_dof_transformation(_coeffs, cell_info, cell, 1);
 
         // Copy interpolation dofs into coefficient vector
@@ -865,7 +974,7 @@ void interpolate(
 /// @param[in] cells List of cell indices to interpolate on
 template <typename T>
 void interpolate(Function<T>& u, const Function<T>& v,
-                 const xtl::span<const std::int32_t>& cells)
+                 const std::span<const std::int32_t>& cells)
 {
   assert(u.function_space());
   assert(v.function_space());
@@ -878,8 +987,8 @@ void interpolate(Function<T>& u, const Function<T>& v,
   if (u.function_space() == v.function_space() and cells.size() == num_cells0)
   {
     // Same function spaces and on whole mesh
-    xtl::span<T> u1_array = u.x()->mutable_array();
-    xtl::span<const T> u0_array = v.x()->array();
+    std::span<T> u1_array = u.x()->mutable_array();
+    std::span<const T> u0_array = v.x()->array();
     std::copy(u0_array.begin(), u0_array.end(), u1_array.begin());
   }
   else
@@ -889,12 +998,16 @@ void interpolate(Function<T>& u, const Function<T>& v,
       impl::interpolate_nonmatching_meshes(u, v, cells);
     else
     {
+
       // Get elements and check value shape
       auto element0 = v.function_space()->element();
       assert(element0);
       auto element1 = u.function_space()->element();
       assert(element1);
-      if (element0->value_shape() != element1->value_shape())
+      if (element0->value_shape().size() != element1->value_shape().size()
+          or !std::equal(element0->value_shape().begin(),
+                         element0->value_shape().end(),
+                         element1->value_shape().begin()))
       {
         throw std::runtime_error(
             "Interpolation: elements have different value dimensions");
@@ -911,33 +1024,31 @@ void interpolate(Function<T>& u, const Function<T>& v,
         assert(element1->block_size() == element0->block_size());
 
         // Get dofmaps
-        std::shared_ptr<const fem::DofMap> dofmap0
-            = v.function_space()->dofmap();
+        std::shared_ptr<const DofMap> dofmap0 = v.function_space()->dofmap();
         assert(dofmap0);
-        std::shared_ptr<const fem::DofMap> dofmap1
-            = u.function_space()->dofmap();
+        std::shared_ptr<const DofMap> dofmap1 = u.function_space()->dofmap();
         assert(dofmap1);
 
-        xtl::span<T> u1_array = u.x()->mutable_array();
-        xtl::span<const T> u0_array = v.x()->array();
+        std::span<T> u1_array = u.x()->mutable_array();
+        std::span<const T> u0_array = v.x()->array();
 
         // Iterate over mesh and interpolate on each cell
         const int bs0 = dofmap0->bs();
         const int bs1 = dofmap1->bs();
         for (auto c : cells)
         {
-          xtl::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
-          xtl::span<const std::int32_t> dofs1 = dofmap1->cell_dofs(c);
+          std::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
+          std::span<const std::int32_t> dofs1 = dofmap1->cell_dofs(c);
           assert(bs0 * dofs0.size() == bs1 * dofs1.size());
           for (std::size_t i = 0; i < dofs0.size(); ++i)
           {
-            for (int k = 0; k < bs0; ++k)
-            {
-              int index = bs0 * i + k;
-              std::div_t dv1 = std::div(index, bs1);
-              u1_array[bs1 * dofs1[dv1.quot] + dv1.rem]
-                  = u0_array[bs0 * dofs0[i] + k];
-            }
+              for (int k = 0; k < bs0; ++k)
+              {
+                int index = bs0 * i + k;
+                std::div_t dv1 = std::div(index, bs1);
+                u1_array[bs1 * dofs1[dv1.quot] + dv1.rem]
+                    = u0_array[bs0 * dofs0[i] + k];
+              }
           }
         }
       }

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -13,7 +13,7 @@
 #include <dolfinx/la/petsc.h>
 #include <functional>
 #include <petscistypes.h>
-#include <xtl/xspan.hpp>
+#include <span>
 
 using namespace dolfinx;
 
@@ -267,9 +267,9 @@ Vec fem::petsc::create_vector_nest(
 //-----------------------------------------------------------------------------
 void fem::petsc::assemble_vector(
     Vec b, const Form<PetscScalar>& L,
-    const xtl::span<const PetscScalar>& constants,
+    const std::span<const PetscScalar>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const PetscScalar>, int>>& coeffs)
+                   std::pair<std::span<const PetscScalar>, int>>& coeffs)
 {
   Vec b_local;
   VecGhostGetLocalForm(b, &b_local);
@@ -277,7 +277,7 @@ void fem::petsc::assemble_vector(
   VecGetSize(b_local, &n);
   PetscScalar* array = nullptr;
   VecGetArray(b_local, &array);
-  xtl::span<PetscScalar> _b(array, n);
+  std::span<PetscScalar> _b(array, n);
   fem::assemble_vector<PetscScalar>(_b, L, constants, coeffs);
   VecRestoreArray(b_local, &array);
   VecGhostRestoreLocalForm(b, &b_local);
@@ -291,7 +291,7 @@ void fem::petsc::assemble_vector(Vec b, const Form<PetscScalar>& L)
   VecGetSize(b_local, &n);
   PetscScalar* array = nullptr;
   VecGetArray(b_local, &array);
-  xtl::span<PetscScalar> _b(array, n);
+  std::span<PetscScalar> _b(array, n);
   fem::assemble_vector<PetscScalar>(_b, L);
   VecRestoreArray(b_local, &array);
   VecGhostRestoreLocalForm(b, &b_local);
@@ -299,9 +299,9 @@ void fem::petsc::assemble_vector(Vec b, const Form<PetscScalar>& L)
 //-----------------------------------------------------------------------------
 void fem::petsc::apply_lifting(
     Vec b, const std::vector<std::shared_ptr<const Form<PetscScalar>>>& a,
-    const std::vector<xtl::span<const PetscScalar>>& constants,
+    const std::vector<std::span<const PetscScalar>>& constants,
     const std::vector<std::map<std::pair<IntegralType, int>,
-                               std::pair<xtl::span<const PetscScalar>, int>>>&
+                               std::pair<std::span<const PetscScalar>, int>>>&
         coeffs,
     const std::vector<
         std::vector<std::shared_ptr<const DirichletBC<PetscScalar>>>>& bcs1,
@@ -313,13 +313,13 @@ void fem::petsc::apply_lifting(
   VecGetSize(b_local, &n);
   PetscScalar* array = nullptr;
   VecGetArray(b_local, &array);
-  xtl::span<PetscScalar> _b(array, n);
+  std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
     fem::apply_lifting<PetscScalar>(_b, a, constants, coeffs, bcs1, {}, scale);
   else
   {
-    std::vector<xtl::span<const PetscScalar>> x0_ref;
+    std::vector<std::span<const PetscScalar>> x0_ref;
     std::vector<Vec> x0_local(a.size());
     std::vector<const PetscScalar*> x0_array(a.size());
     for (std::size_t i = 0; i < a.size(); ++i)
@@ -359,13 +359,13 @@ void fem::petsc::apply_lifting(
   VecGetSize(b_local, &n);
   PetscScalar* array = nullptr;
   VecGetArray(b_local, &array);
-  xtl::span<PetscScalar> _b(array, n);
+  std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
     fem::apply_lifting<PetscScalar>(_b, a, bcs1, {}, scale);
   else
   {
-    std::vector<xtl::span<const PetscScalar>> x0_ref;
+    std::vector<std::span<const PetscScalar>> x0_ref;
     std::vector<Vec> x0_local(a.size());
     std::vector<const PetscScalar*> x0_array(a.size());
     for (std::size_t i = 0; i < a.size(); ++i)
@@ -401,7 +401,7 @@ void fem::petsc::set_bc(
   VecGetLocalSize(b, &n);
   PetscScalar* array = nullptr;
   VecGetArray(b, &array);
-  xtl::span<PetscScalar> _b(array, n);
+  std::span<PetscScalar> _b(array, n);
   if (x0)
   {
     Vec x0_local;
@@ -410,7 +410,7 @@ void fem::petsc::set_bc(
     VecGetSize(x0_local, &n);
     const PetscScalar* array = nullptr;
     VecGetArrayRead(x0_local, &array);
-    xtl::span<const PetscScalar> _x0(array, n);
+    std::span<const PetscScalar> _x0(array, n);
     fem::set_bc<PetscScalar>(_b, bcs, _x0, scale);
     VecRestoreArrayRead(x0_local, &array);
     VecGhostRestoreLocalForm(x0, &x0_local);

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -11,9 +11,9 @@
 #include <memory>
 #include <petscmat.h>
 #include <petscvec.h>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::common
 {
@@ -84,9 +84,9 @@ Vec create_vector_nest(
 /// @param[in] coeffs The coefficients that appear in `L`
 void assemble_vector(
     Vec b, const Form<PetscScalar>& L,
-    const xtl::span<const PetscScalar>& constants,
+    const std::span<const PetscScalar>& constants,
     const std::map<std::pair<IntegralType, int>,
-                   std::pair<xtl::span<const PetscScalar>, int>>& coeffs);
+                   std::pair<std::span<const PetscScalar>, int>>& coeffs);
 
 /// Assemble linear form into an already allocated PETSc vector. Ghost
 /// contributions are not accumulated (not sent to owner). Caller is
@@ -119,9 +119,9 @@ void assemble_vector(Vec b, const Form<PetscScalar>& L);
 /// is responsible for calling VecGhostUpdateBegin/End.
 void apply_lifting(
     Vec b, const std::vector<std::shared_ptr<const Form<PetscScalar>>>& a,
-    const std::vector<xtl::span<const PetscScalar>>& constants,
+    const std::vector<std::span<const PetscScalar>>& constants,
     const std::vector<std::map<std::pair<IntegralType, int>,
-                               std::pair<xtl::span<const PetscScalar>, int>>>&
+                               std::pair<std::span<const PetscScalar>, int>>>&
         coeffs,
     const std::vector<
         std::vector<std::shared_ptr<const DirichletBC<PetscScalar>>>>& bcs1,

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -30,7 +30,7 @@ void sparsitybuild::cells(
 }
 //-----------------------------------------------------------------------------
 void sparsitybuild::cells(
-    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& cells,
+    la::SparsityPattern& pattern, const std::span<const std::int32_t>& cells,
     const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   for (std::int32_t c : cells)
@@ -87,7 +87,7 @@ void sparsitybuild::interior_facets(
 }
 //-----------------------------------------------------------------------------
 void sparsitybuild::interior_facets(
-    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
+    la::SparsityPattern& pattern, const std::span<const std::int32_t>& facets,
     const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   std::array<std::vector<std::int32_t>, 2> macro_dofs;
@@ -139,7 +139,7 @@ void sparsitybuild::exterior_facets(
 }
 //-----------------------------------------------------------------------------
 void sparsitybuild::exterior_facets(
-    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
+    la::SparsityPattern& pattern, const std::span<const std::int32_t>& facets,
     const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   for (std::size_t index = 0; index < facets.size(); index += 2)

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -7,8 +7,9 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <functional>
-#include <xtl/xspan.hpp>
+#include <span>
 
 namespace dolfinx::la
 {
@@ -48,7 +49,7 @@ void cells(
 /// pattern
 /// @note The sparsity pattern is not finalised
 void cells(
-    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& cells,
+    la::SparsityPattern& pattern, const std::span<const std::int32_t>& cells,
     const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 /// @brief Iterate over interior facets and insert entries into sparsity
@@ -74,7 +75,7 @@ void interior_facets(
 /// pattern
 /// @note The sparsity pattern is not finalised
 void interior_facets(
-    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
+    la::SparsityPattern& pattern, const std::span<const std::int32_t>& facets,
     const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 /// @brief Iterate over exterior facets and insert entries into sparsity
@@ -99,7 +100,7 @@ void exterior_facets(
 /// pattern
 /// @note The sparsity pattern is not finalised
 void exterior_facets(
-    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
+    la::SparsityPattern& pattern, const std::span<const std::int32_t>& facets,
     const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 } // namespace sparsitybuild

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -175,7 +175,7 @@ fem::create_dofmap(MPI_Comm comm, const ElementDofLayout& layout,
     const std::vector<std::uint32_t>& cell_info
         = topology.get_cell_permutation_info();
 
-    const std::function<void(const xtl::span<std::int32_t>&, std::uint32_t)>
+    const std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
         unpermute_dofs = element.get_dof_permutation_function(true, true);
     for (std::int32_t cell = 0; cell < num_cells; ++cell)
       unpermute_dofs(dofmap.links(cell), cell_info[cell]);

--- a/cpp/dolfinx/geometry/BoundingBoxTree.cpp
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.cpp
@@ -13,7 +13,6 @@
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/utils.h>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::geometry;
@@ -39,10 +38,10 @@ std::array<std::array<double, 3>, 2>
 compute_bbox_of_entity(const mesh::Mesh& mesh, int dim, std::int32_t index)
 {
   // Get the geometrical indices for the mesh entity
-  xtl::span<const double> xg = mesh.geometry().x();
+  std::span<const double> xg = mesh.geometry().x();
 
   // FIXME: return of small dynamic array is expensive
-  xtl::span<const std::int32_t> entity(&index, 1);
+  std::span<const std::int32_t> entity(&index, 1);
   const std::vector<std::int32_t> vertex_indices
       = mesh::entities_to_geometry(mesh, dim, entity, false);
 
@@ -52,7 +51,7 @@ compute_bbox_of_entity(const mesh::Mesh& mesh, int dim, std::int32_t index)
   b[1] = b[0];
 
   // Compute min and max over vertices
-  for (const int local_vertex : vertex_indices)
+  for (int local_vertex : vertex_indices)
   {
     for (int j = 0; j < 3; ++j)
     {
@@ -66,7 +65,7 @@ compute_bbox_of_entity(const mesh::Mesh& mesh, int dim, std::int32_t index)
 //-----------------------------------------------------------------------------
 // Compute bounding box of bounding boxes
 std::array<std::array<double, 3>, 2> compute_bbox_of_bboxes(
-    const xtl::span<const std::pair<std::array<std::array<double, 3>, 2>,
+    const std::span<const std::pair<std::array<std::array<double, 3>, 2>,
                                     std::int32_t>>& leaf_bboxes)
 {
   // Compute min and max over remaining boxes
@@ -87,7 +86,7 @@ std::array<std::array<double, 3>, 2> compute_bbox_of_bboxes(
 }
 //------------------------------------------------------------------------------
 int _build_from_leaf(
-    xtl::span<std::pair<std::array<std::array<double, 3>, 2>, std::int32_t>>
+    std::span<std::pair<std::array<std::array<double, 3>, 2>, std::int32_t>>
         leaf_bboxes,
     std::vector<std::array<int, 2>>& bboxes,
     std::vector<double>& bbox_coordinates)
@@ -123,20 +122,21 @@ int _build_from_leaf(
         b_diff.begin(), std::max_element(b_diff.begin(), b_diff.end()));
 
     auto middle = std::next(leaf_bboxes.begin(), leaf_bboxes.size() / 2);
-
     std::nth_element(leaf_bboxes.begin(), middle, leaf_bboxes.end(),
-                     [axis](const auto& p0, const auto& p1) -> bool
+                     [axis](auto& p0, auto& p1) -> bool
                      {
-                       const double x0 = p0.first[0][axis] + p0.first[1][axis];
-                       const double x1 = p1.first[0][axis] + p1.first[1][axis];
+                       double x0 = p0.first[0][axis] + p0.first[1][axis];
+                       double x1 = p1.first[0][axis] + p1.first[1][axis];
                        return x0 < x1;
                      });
 
     // Split bounding boxes into two groups and call recursively
-    std::array bbox{_build_from_leaf(xtl::span(leaf_bboxes.begin(), middle),
-                                     bboxes, bbox_coordinates),
-                    _build_from_leaf(xtl::span(middle, leaf_bboxes.end()),
-                                     bboxes, bbox_coordinates)};
+    assert(!leaf_bboxes.empty());
+    std::size_t part = leaf_bboxes.size() / 2;
+    std::array bbox{
+        _build_from_leaf(leaf_bboxes.first(part), bboxes, bbox_coordinates),
+        _build_from_leaf(leaf_bboxes.last(leaf_bboxes.size() - part), bboxes,
+                         bbox_coordinates)};
 
     // Store bounding box data. Note that root box will be added last.
     bboxes.push_back(bbox);
@@ -165,7 +165,7 @@ std::pair<std::vector<std::int32_t>, std::vector<double>> build_from_leaf(
 }
 //-----------------------------------------------------------------------------
 int _build_from_point(
-    xtl::span<std::pair<std::array<double, 3>, std::int32_t>> points,
+    std::span<std::pair<std::array<double, 3>, std::int32_t>> points,
     std::vector<std::array<std::int32_t, 2>>& bboxes,
     std::vector<double>& bbox_coordinates)
 {
@@ -195,18 +195,19 @@ int _build_from_point(
                  std::minus<double>());
   const std::size_t axis = std::distance(
       b_diff.begin(), std::max_element(b_diff.begin(), b_diff.end()));
+
   auto middle = std::next(points.begin(), points.size() / 2);
-  std::nth_element(
-      points.begin(), middle, points.end(),
-      [axis](const std::pair<std::array<double, 3>, std::int32_t>& p0,
-             const std::pair<std::array<double, 3>, std::int32_t>& p1) -> bool
-      { return p0.first[axis] < p1.first[axis]; });
+  std::nth_element(points.begin(), middle, points.end(),
+                   [axis](auto& p0, auto&& p1) -> bool
+                   { return p0.first[axis] < p1.first[axis]; });
 
   // Split bounding boxes into two groups and call recursively
-  std::array bbox{_build_from_point(xtl::span(points.begin(), middle), bboxes,
-                                    bbox_coordinates),
-                  _build_from_point(xtl::span(middle, points.end()), bboxes,
-                                    bbox_coordinates)};
+  assert(!points.empty());
+  std::size_t part = points.size() / 2;
+  std::array bbox{
+      _build_from_point(points.first(part), bboxes, bbox_coordinates),
+      _build_from_point(points.last(points.size() - part), bboxes,
+                        bbox_coordinates)};
 
   // Store bounding box data. Note that root box will be added last.
   bboxes.push_back(bbox);
@@ -226,7 +227,7 @@ BoundingBoxTree::BoundingBoxTree(const mesh::Mesh& mesh, int tdim,
 }
 //-----------------------------------------------------------------------------
 BoundingBoxTree::BoundingBoxTree(const mesh::Mesh& mesh, int tdim,
-                                 const xtl::span<const std::int32_t>& entities,
+                                 const std::span<const std::int32_t>& entities,
                                  double padding)
     : _tdim(tdim)
 {
@@ -267,13 +268,11 @@ BoundingBoxTree::BoundingBoxTree(
     std::vector<std::pair<std::array<double, 3>, std::int32_t>> points)
     : _tdim(0)
 {
-  const std::int32_t num_leaves = points.size();
-
   // Recursively build the bounding box tree from the leaves
   std::vector<std::array<int, 2>> bboxes;
-  if (num_leaves > 0)
+  if (!points.empty())
   {
-    _build_from_point(tcb::make_span(points), bboxes, _bbox_coordinates);
+    _build_from_point(std::span(points), bboxes, _bbox_coordinates);
     _bboxes.resize(2 * bboxes.size());
     for (std::size_t i = 0; i < bboxes.size(); ++i)
     {
@@ -283,7 +282,7 @@ BoundingBoxTree::BoundingBoxTree(
   }
 
   LOG(INFO) << "Computed bounding box tree with " << num_bboxes()
-            << " nodes for " << num_leaves << " points.";
+            << " nodes for " << points.size() << " points.";
 }
 //-----------------------------------------------------------------------------
 BoundingBoxTree::BoundingBoxTree(std::vector<std::int32_t>&& bboxes,
@@ -299,7 +298,7 @@ BoundingBoxTree BoundingBoxTree::create_global_tree(MPI_Comm comm) const
   const int mpi_size = dolfinx::MPI::size(comm);
 
   // Send root node coordinates to all processes
-  std::vector<double> send_bbox(6, 0.0);
+  std::array<double, 6> send_bbox = {0, 0, 0, 0, 0, 0};
   if (num_bboxes() > 0)
     std::copy_n(std::prev(_bbox_coordinates.end(), 6), 6, send_bbox.begin());
   std::vector<double> recv_bbox(mpi_size * 6);
@@ -363,14 +362,14 @@ void BoundingBoxTree::tree_print(std::stringstream& s, int i) const
   }
 }
 //-----------------------------------------------------------------------------
-xt::xtensor_fixed<double, xt::xshape<2, 3>>
+std::array<std::array<double, 3>, 2>
 BoundingBoxTree::get_bbox(std::size_t node) const
 {
-  xt::xtensor_fixed<double, xt::xshape<2, 3>> x;
+  std::array<std::array<double, 3>, 2> x;
   common::impl::copy_N<3>(std::next(_bbox_coordinates.begin(), 6 * node),
-                          x.begin());
+                          x[0].begin());
   common::impl::copy_N<3>(std::next(_bbox_coordinates.begin(), 6 * node + 3),
-                          std::next(x.begin(), 3));
+                          x[1].begin());
   return x;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/geometry/BoundingBoxTree.h
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.h
@@ -7,10 +7,12 @@
 #pragma once
 
 #include <array>
+#include <cassert>
+#include <cstdint>
 #include <mpi.h>
+#include <span>
+#include <string>
 #include <vector>
-#include <xtensor/xfixed.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::mesh
 {
@@ -22,7 +24,6 @@ namespace dolfinx::geometry
 
 /// Axis-Aligned bounding box binary tree. It is used to find entities
 /// in a collection (often a mesh::Mesh).
-
 class BoundingBoxTree
 {
 
@@ -36,7 +37,7 @@ public:
   /// @param[in] padding A float perscribing how much the bounding box
   /// of each entity should be padded
   BoundingBoxTree(const mesh::Mesh& mesh, int tdim,
-                  const xtl::span<const std::int32_t>& entities,
+                  const std::span<const std::int32_t>& entities,
                   double padding = 0);
 
   /// Constructor
@@ -71,7 +72,7 @@ public:
   /// @param[in] node The bounding box node index
   /// @return The bounding box where [0] is the lower corner and [1] is
   /// the upper corner
-  xt::xtensor_fixed<double, xt::xshape<2, 3>> get_bbox(std::size_t node) const;
+  std::array<std::array<double, 3>, 2> get_bbox(std::size_t node) const;
 
   /// Compute a global bounding tree (collective on comm)
   /// This can be used to find which process a point might have a

--- a/cpp/dolfinx/geometry/gjk.cpp
+++ b/cpp/dolfinx/geometry/gjk.cpp
@@ -6,61 +6,76 @@
 
 #include "gjk.h"
 #include <dolfinx/common/math.h>
+#include <numeric>
 #include <stdexcept>
-#include <tuple>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xfixed.hpp>
-#include <xtensor/xnorm.hpp>
-#include <xtensor/xsort.hpp>
-#include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 
 namespace
 {
 
-// Find the resulting sub-simplex of the input simplex which is nearest to the
-// origin. Also, return the shortest vector from the origin to the resulting
-// simplex.
-std::pair<xt::xtensor<double, 2>, xt::xtensor_fixed<double, xt::xshape<3>>>
-nearest_simplex(const xt::xtensor<double, 2>& s)
+/// @brief Find the resulting sub-simplex of the input simplex which is
+/// nearest to the origin. Also, return the shortest vector from the
+/// origin to the resulting simplex.
+std::pair<std::vector<double>, std::array<double, 3>>
+nearest_simplex(const std::span<const double>& s)
 {
-  assert(s.shape(1) == 3);
-  const std::size_t s_rows = s.shape(0);
+  assert(s.size() % 3 == 0);
+  const std::size_t s_rows = s.size() / 3;
   switch (s_rows)
   {
   case 2:
   {
-    auto s0 = xt::row(s, 0);
-    auto s1 = xt::row(s, 1);
-    const double lm = -xt::sum(s0 * (s1 - s0))() / xt::norm_sq(s1 - s0)();
+    // Compute lm = dot(s0, ds / |ds|)
+    auto s0 = s.subspan(0, 3);
+    auto s1 = s.subspan(3, 3);
+    std::array ds = {s1[0] - s0[0], s1[1] - s0[1], s1[2] - s0[2]};
+    const double lm = -(s0[0] * ds[0] + s0[1] * ds[1] + s0[2] * ds[2])
+                      / (ds[0] * ds[0] + ds[1] * ds[1] + ds[2] * ds[2]);
     if (lm >= 0.0 and lm <= 1.0)
     {
       // The origin is between A and B
-      auto v = s0 + lm * (s1 - s0);
-      return {s, v};
+      // v = s0 + lm * (s1 - s0);
+      std::array<double, 3> v
+          = {s0[0] + lm * ds[0], s0[1] + lm * ds[1], s0[2] + lm * ds[2]};
+      return {std::vector<double>(s.begin(), s.end()), v};
     }
 
     if (lm < 0.0)
-      return {xt::reshape_view(s0, {1, 3}), s0};
+      return {std::vector<double>(s0.begin(), s0.end()), {s0[0], s0[1], s0[2]}};
     else
-      return {xt::reshape_view(s1, {1, 3}), s1};
+      return {std::vector<double>(s1.begin(), s1.end()), {s1[0], s1[1], s1[2]}};
   }
   case 3:
   {
-    const auto a = xt::row(s, 0);
-    const auto b = xt::row(s, 1);
-    const auto c = xt::row(s, 2);
-    const double ab2 = xt::norm_sq(a - b)();
-    const double ac2 = xt::norm_sq(a - c)();
-    const double bc2 = xt::norm_sq(b - c)();
-    const xt::xtensor_fixed<double, xt::xshape<3>> lm
-        = {xt::sum(a * (a - b))() / ab2, xt::sum(a * (a - c))() / ac2,
-           xt::sum(b * (b - c))() / bc2};
+    auto a = s.subspan(0, 3);
+    auto b = s.subspan(3, 3);
+    auto c = s.subspan(6, 3);
+    auto length = [](auto& x, auto& y)
+    {
+      return std::transform_reduce(
+          x.begin(), x.end(), y.begin(), 0.0, std::plus{},
+          [](auto x, auto y) { return (x - y) * (x - y); });
+    };
+    const double ab2 = length(a, b);
+    const double ac2 = length(a, c);
+    const double bc2 = length(b, c);
+
+    // Helper to compute dot(x, x - y)
+    auto helper = [](auto& x, auto& y)
+    {
+      return std::transform_reduce(x.begin(), x.end(), y.begin(), 0.0,
+                                   std::plus{},
+                                   [](auto x, auto y) { return x * (x - y); });
+    };
+    const std::array<double, 3> lm
+        = {helper(a, b) / ab2, helper(a, c) / ac2, helper(b, c) / bc2};
+
+    double caba = 0;
+    for (std::size_t i = 0; i < 3; ++i)
+      caba += (c[i] - a[i]) * (b[i] - a[i]);
 
     // Calculate triangle ABC
-    const double caba = xt::sum((c - a) * (b - a))();
     const double c2 = 1 - caba * caba / (ab2 * ac2);
     const double lbb = (lm[0] - lm[1] * caba / ab2) / c2;
     const double lcc = (lm[1] - lm[0] * caba / ac2) / c2;
@@ -69,41 +84,70 @@ nearest_simplex(const xt::xtensor<double, 2>& s)
     if (lbb >= 0.0 and lcc >= 0.0 and (lbb + lcc) <= 1.0)
     {
       // Calculate intersection more accurately
-      auto v = math::cross(c - a, b - a);
+      // v = (c - a)  x (b - a)
+      std::array<double, 3> dx0 = {c[0] - a[0], c[1] - a[1], c[2] - a[2]};
+      std::array<double, 3> dx1 = {b[0] - a[0], b[1] - a[1], b[2] - a[2]};
+      std::array<double, 3> v = math::cross(dx0, dx1);
 
       // Barycentre of triangle
-      auto p = (a + b + c) / 3.0;
+      std::array<double, 3> p
+          = {(a[0] + b[0] + c[0]) / 3, (a[1] + b[1] + c[1]) / 3,
+             (a[2] + b[2] + c[2]) / 3};
 
-      // Renormalise n in plane of ABC
-      v *= xt::sum(v * p) / xt::norm_sq(v);
-      return {std::move(s), v};
+      double sum = v[0] * p[0] + v[1] * p[1] + v[2] * p[2];
+      double vnorm2 = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+      for (std::size_t i = 0; i < 3; ++i)
+        v[i] *= sum / vnorm2;
+
+      return {std::vector<double>(s.begin(), s.end()), v};
     }
 
     // Get closest point
-    std::size_t i = xt::argmin(xt::norm_sq(s, {1}))();
-    xt::xtensor_fixed<double, xt::xshape<3>> vmin = xt::row(s, i);
-    double qmin = xt::norm_sq(vmin)();
+    std::size_t pos = 0;
+    {
+      double norm0 = std::numeric_limits<double>::max();
+      for (std::size_t i = 0; i < s.size(); i += 3)
+      {
+        std::span<const double, 3> p(s.data() + i, 3);
+        double norm = p[0] * p[0] + p[1] * p[1] + p[2] * p[2];
+        if (norm < norm0)
+        {
+          pos = i / 3;
+          norm0 = norm;
+        }
+      }
+    }
 
-    xt::xtensor<double, 2> smin({1, 3});
-    xt::row(smin, 0) = vmin;
+    std::array vmin = {s[3 * pos], s[3 * pos + 1], s[3 * pos + 2]};
+    double qmin = 0;
+    for (std::size_t k = 0; k < 3; ++k)
+      qmin += vmin[k] * vmin[k];
+
+    std::vector<double> smin = {vmin[0], vmin[1], vmin[2]};
 
     // Check if edges are closer
     constexpr const int f[3][2] = {{0, 1}, {0, 2}, {1, 2}};
     for (std::size_t i = 0; i < s_rows; ++i)
     {
-      auto s0 = xt::row(s, f[i][0]);
-      auto s1 = xt::row(s, f[i][1]);
+      auto s0 = s.subspan(3 * f[i][0], 3);
+      auto s1 = s.subspan(3 * f[i][1], 3);
       if (lm[i] > 0 and lm[i] < 1)
       {
-        auto v = s0 + lm[i] * (s1 - s0);
-        const double qnorm = xt::norm_sq(v)();
+        std::array<double, 3> v;
+        for (std::size_t k = 0; k < 3; ++k)
+          v[k] = s0[k] + lm[i] * (s1[k] - s0[k]);
+        double qnorm = 0;
+        for (std::size_t k = 0; k < 3; ++k)
+          qnorm += v[k] * v[k];
         if (qnorm < qmin)
         {
-          vmin = v;
+          std::copy(v.begin(), v.end(), vmin.begin());
           qmin = qnorm;
-          smin.resize({2, 3});
-          xt::row(smin, 0) = s0;
-          xt::row(smin, 1) = s1;
+          smin.resize(2 * 3);
+          std::span<double, 3> smin0(smin.data(), 3);
+          std::copy(s0.begin(), s0.end(), smin0.begin());
+          std::span<double, 3> smin1(smin.data() + 3, 3);
+          std::copy(s1.begin(), s1.end(), smin1.begin());
         }
       }
     }
@@ -111,20 +155,20 @@ nearest_simplex(const xt::xtensor<double, 2>& s)
   }
   case 4:
   {
-    auto s0 = xt::row(s, 0);
-    auto s1 = xt::row(s, 1);
-    auto s2 = xt::row(s, 2);
-    auto s3 = xt::row(s, 3);
+    auto s0 = s.subspan(0, 3);
+    auto s1 = s.subspan(3, 3);
+    auto s2 = s.subspan(6, 3);
+    auto s3 = s.subspan(9, 3);
     auto W1 = math::cross(s0, s1);
     auto W2 = math::cross(s2, s3);
 
-    xt::xtensor_fixed<double, xt::xshape<4>> B;
-    B[0] = xt::sum(s2 * W1)();
-    B[1] = -xt::sum(s3 * W1)();
-    B[2] = xt::sum(s0 * W2)();
-    B[3] = -xt::sum(s1 * W2)();
+    std::array<double, 4> B;
+    B[0] = std::transform_reduce(s2.begin(), s2.end(), W1.begin(), 0.0);
+    B[1] = -std::transform_reduce(s3.begin(), s3.end(), W1.begin(), 0.0);
+    B[2] = std::transform_reduce(s0.begin(), s0.end(), W2.begin(), 0.0);
+    B[3] = -std::transform_reduce(s1.begin(), s1.end(), W2.begin(), 0.0);
 
-    const bool signDetM = std::signbit(xt::sum(B)());
+    const bool signDetM = std::signbit(std::reduce(B.begin(), B.end(), 0.0));
     std::array<bool, 4> f_inside;
     for (int i = 0; i < 4; ++i)
       f_inside[i] = (std::signbit(B[i]) == signDetM);
@@ -132,27 +176,29 @@ nearest_simplex(const xt::xtensor<double, 2>& s)
     if (f_inside[1] and f_inside[2] and f_inside[3])
     {
       if (f_inside[0]) // The origin is inside the tetrahedron
-        return {s, xt::zeros<double>({3})};
+        return {std::vector<double>(s.begin(), s.end()), {0, 0, 0}};
       else // The origin projection P faces BCD
-        return nearest_simplex(xt::view(s, xt::range(0, 3), xt::all()));
+        return nearest_simplex(s.subspan(0, 3 * 3));
     }
 
-    // Test ACD, ABD and/or ABC.
-    xt::xtensor<double, 2> smin;
-    xt::xtensor_fixed<double, xt::xshape<3>> vmin = xt::zeros<double>({3});
+    // Test ACD, ABD and/or ABC
+    std::vector<double> smin;
+    std::array<double, 3> vmin = {0, 0, 0};
     constexpr int facets[3][3] = {{0, 1, 3}, {0, 2, 3}, {1, 2, 3}};
     double qmin = std::numeric_limits<double>::max();
+    std::vector<double> M(9);
     for (int i = 0; i < 3; ++i)
     {
       if (f_inside[i + 1] == false)
       {
-        xt::xtensor_fixed<double, xt::xshape<3, 3>> M;
-        xt::row(M, 0) = xt::row(s, facets[i][0]);
-        xt::row(M, 1) = xt::row(s, facets[i][1]);
-        xt::row(M, 2) = xt::row(s, facets[i][2]);
+        std::copy_n(std::next(s.begin(), 3 * facets[i][0]), 3, M.begin());
+        std::copy_n(std::next(s.begin(), 3 * facets[i][1]), 3,
+                    std::next(M.begin(), 3));
+        std::copy_n(std::next(s.begin(), 3 * facets[i][2]), 3,
+                    std::next(M.begin(), 6));
 
         const auto [snew, v] = nearest_simplex(M);
-        const double q = xt::norm_sq(v)();
+        double q = std::transform_reduce(v.begin(), v.end(), v.begin(), 0);
         if (q < qmin)
         {
           qmin = q;
@@ -161,25 +207,23 @@ nearest_simplex(const xt::xtensor<double, 2>& s)
         }
       }
     }
-    return {std::move(smin), vmin};
+    return {smin, vmin};
   }
   default:
-  {
     throw std::runtime_error("Number of rows defining simplex not supported.");
-  }
   }
 }
 //----------------------------------------------------------------------------
-// Support function, finds point p in bd which maximises p.v
-xt::xtensor_fixed<double, xt::xshape<3>>
-support(const xt::xtensor<double, 2>& bd,
-        const xt::xtensor_fixed<double, xt::xshape<3>>& v)
+
+/// @brief 'support' function, finds point p in bd which maximises p.v
+std::array<double, 3> support(const std::span<const double>& bd,
+                              const std::array<double, 3>& v)
 {
   int i = 0;
-  double qmax = xt::sum(xt::row(bd, 0) * v)();
-  for (std::size_t m = 1; m < bd.shape(0); ++m)
+  double qmax = bd[0] * v[0] + bd[1] * v[1] + bd[2] * v[2];
+  for (std::size_t m = 1; m < bd.size() / 3; ++m)
   {
-    double q = xt::sum(xt::row(bd, m) * v)();
+    double q = bd[3 * m] * v[0] + bd[3 * m + 1] * v[1] + bd[3 * m + 2] * v[2];
     if (q > qmax)
     {
       qmax = q;
@@ -187,16 +231,16 @@ support(const xt::xtensor<double, 2>& bd,
     }
   }
 
-  return xt::row(bd, i);
+  return {bd[3 * i], bd[3 * i + 1], bd[3 * i + 2]};
 }
 } // namespace
 //----------------------------------------------------------------------------
-xt::xtensor_fixed<double, xt::xshape<3>>
-geometry::compute_distance_gjk(const xt::xtensor<double, 2>& p,
-                               const xt::xtensor<double, 2>& q)
+std::array<double, 3>
+geometry::compute_distance_gjk(const std::span<const double>& p,
+                               const std::span<const double>& q)
 {
-  assert(p.shape(1) == 3);
-  assert(q.shape(1) == 3);
+  assert(p.size() % 3 == 0);
+  assert(q.size() % 3 == 0);
 
   constexpr int maxk = 10; // Maximum number of iterations of the GJK algorithm
 
@@ -204,46 +248,47 @@ geometry::compute_distance_gjk(const xt::xtensor<double, 2>& p,
   constexpr double eps = 1e-12;
 
   // Initialise vector and simplex
-  xt::xtensor_fixed<double, xt::xshape<3>> v = xt::row(p, 0) - xt::row(q, 0);
-  xt::xtensor<double, 2> s({1, 3});
-  xt::row(s, 0) = v;
+  std::array<double, 3> v = {p[0] - q[0], p[1] - q[1], p[2] - q[2]};
+  std::vector<double> s = {v[0], v[1], v[2]};
 
   // Begin GJK iteration
   int k;
   for (k = 0; k < maxk; ++k)
   {
     // Support function
-    const xt::xtensor_fixed<double, xt::xshape<3>> w
-        = support(p, -v) - support(q, v);
+    std::array w1 = support(p, {-v[0], -v[1], -v[2]});
+    std::array w0 = support(q, {v[0], v[1], v[2]});
+    const std::array w = {w1[0] - w0[0], w1[1] - w0[1], w1[2] - w0[2]};
 
     // Break if any existing points are the same as w
-    assert(s.shape(1) == 3);
+    assert(s.size() % 3 == 0);
     std::size_t m;
-    for (m = 0; m < s.shape(0); ++m)
+    for (m = 0; m < s.size() / 3; ++m)
     {
-      if (xt::row(s, m) == w)
+      auto it = std::next(s.begin(), 3 * m);
+      if (std::equal(it, std::next(it, 3), w.begin(), w.end()))
         break;
     }
 
-    if (m != s.shape(0))
+    if (m != s.size() / 3)
       break;
 
     // 1st exit condition (v - w).v = 0
-    const double vnorm2 = xt::norm_sq(v)();
-    const double vw = vnorm2 - xt::sum(v * w)();
+    const double vnorm2 = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+    const double vw = vnorm2 - (v[0] * w[0] + v[1] * w[1] + v[2] * w[2]);
     if (vw < (eps * vnorm2) or vw < eps)
       break;
 
     // Add new vertex to simplex
-    s = xt::vstack(xt::xtuple(s, xt::reshape_view(w, {1, 3})));
-    assert(s.shape(1) == 3);
+    s.insert(s.end(), w.begin(), w.end());
 
     // Find nearest subset of simplex
-    std::tie(s, v) = nearest_simplex(s);
-    assert(s.shape(1) == 3);
+    auto [snew, vnew] = nearest_simplex(s);
+    s.assign(snew.data(), snew.data() + snew.size());
+    v = {vnew[0], vnew[1], vnew[2]};
 
     // 2nd exit condition - intersecting or touching
-    if (xt::norm_sq(v)() < eps * eps)
+    if ((v[0] * v[0] + v[1] * v[1] + v[2] * v[2]) < eps * eps)
       break;
   }
 

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <xtensor/xfixed.hpp>
-#include <xtensor/xtensor.hpp>
+#include <array>
+#include <span>
 
 namespace dolfinx::geometry
 {
@@ -16,12 +16,12 @@ namespace dolfinx::geometry
 /// defined by a set of points, using the Gilbert–Johnson–Keerthi (GJK)
 /// distance algorithm.
 ///
-/// @param[in] p Body 1 list of points, shape (num_points, 3)
-/// @param[in] q Body 2 list of points, shape (num_points, 3)
+/// @param[in] p Body 1 list of points, shape (num_points, 3). Row-major
+/// storage.
+/// @param[in] q Body 2 list of points, shape (num_points, 3). Row-major
+/// storage.
 /// @return shortest vector between bodies
-/// @note Avoid allocation of output, use input/output parameters instead.
-xt::xtensor_fixed<double, xt::xshape<3>>
-compute_distance_gjk(const xt::xtensor<double, 2>& p,
-                     const xt::xtensor<double, 2>& q);
+std::array<double, 3> compute_distance_gjk(const std::span<const double>& p,
+                                           const std::span<const double>& q);
 
 } // namespace dolfinx::geometry

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -505,7 +505,7 @@ int geometry::compute_first_colliding_cell(
   {
     constexpr double eps2 = 1e-20;
     const mesh::Geometry& geometry = mesh.geometry();
-    xtl::span<const double> geom_dofs = geometry.x();
+    std::span<const double> geom_dofs = geometry.x();
     const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
     const std::size_t num_nodes = geometry.cmap().dim();
     std::vector<double> coordinate_dofs(num_nodes * 3);

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -515,7 +515,6 @@ int geometry::compute_first_colliding_cell(
       for (std::size_t i = 0; i < num_nodes; ++i)
         common::impl::copy_N<3>(std::next(geom_dofs.begin(), 3 * dofs[i]),
                                 std::next(coordinate_dofs.begin(), 3 * i));
-      // Fix
       std::array<double, 3> shortest_vector
           = geometry::compute_distance_gjk(point, coordinate_dofs);
       double norm = 0;

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -15,10 +15,6 @@
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/utils.h>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xfixed.hpp>
-#include <xtensor/xnorm.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 
@@ -35,17 +31,16 @@ constexpr bool is_leaf(const std::array<int, 2>& bbox)
 /// A point `x` is inside a bounding box `b` if each component of its
 /// coordinates lies within the range `[b(0,i), b(1,i)]` that defines the bounds
 /// of the bounding box, b(0,i) <= x[i] <= b(1,i) for i = 0, 1, 2
-bool point_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
-                   const xt::xtensor_fixed<double, xt::xshape<3>>& x)
+constexpr bool point_in_bbox(const std::array<std::array<double, 3>, 2>& b,
+                             const std::array<double, 3>& x)
 {
   constexpr double rtol = 1e-14;
-  double eps;
   bool in = true;
   for (int i = 0; i < 3; i++)
   {
-    eps = rtol * (b(1, i) - b(0, i));
-    in &= x[i] >= (b(0, i) - eps);
-    in &= x[i] <= (b(1, i) + eps);
+    double eps = rtol * (b[1][i] - b[0][i]);
+    in &= x[i] >= (b[0][i] - eps);
+    in &= x[i] <= (b[1][i] + eps);
   }
 
   return in;
@@ -54,29 +49,25 @@ bool point_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
 /// A bounding box "a" is contained inside another bounding box "b", if each
 /// of its intervals [a(0,i), a(1,i)] is contained in [b(0,i), b(1,i)],
 /// a(0,i) <= b(1, i) and a(1,i) >= b(0, i)
-bool bbox_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& a,
-                  const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b)
+constexpr bool bbox_in_bbox(const std::array<std::array<double, 3>, 2>& a,
+                            const std::array<std::array<double, 3>, 2>& b)
 {
   constexpr double rtol = 1e-14;
-  double eps;
   bool in = true;
-
   for (int i = 0; i < 3; i++)
   {
-    eps = rtol * (b(1, i) - b(0, i));
-    in &= a(1, i) >= (b(0, i) - eps);
-    in &= a(0, i) <= (b(1, i) + eps);
+    double eps = rtol * (b[1][i] - b[0][i]);
+    in &= a[1][i] >= (b[0][i] - eps);
+    in &= a[0][i] <= (b[1][i] + eps);
   }
 
   return in;
 }
 //-----------------------------------------------------------------------------
 // Compute closest entity {closest_entity, R2} (recursive)
-std::pair<std::int32_t, double>
-_compute_closest_entity(const geometry::BoundingBoxTree& tree,
-                        const xt::xtensor_fixed<double, xt::xshape<3>>& point,
-                        int node, const mesh::Mesh& mesh,
-                        std::int32_t closest_entity, double R2)
+std::pair<std::int32_t, double> _compute_closest_entity(
+    const geometry::BoundingBoxTree& tree, const std::array<double, 3>& point,
+    int node, const mesh::Mesh& mesh, std::int32_t closest_entity, double R2)
 {
   // Get children of current bounding box node (child_1 denotes entity
   // index for leaves)
@@ -87,10 +78,10 @@ _compute_closest_entity(const geometry::BoundingBoxTree& tree,
     // If point cloud tree the exact distance is easy to compute
     if (tree.tdim() == 0)
     {
-      xt::xtensor_fixed<double, xt::xshape<3>> diff
-          = xt::row(tree.get_bbox(node), 0);
-      diff -= point;
-      r2 = xt::norm_sq(diff)();
+      std::array<double, 3> diff = tree.get_bbox(node)[0];
+      for (std::size_t k = 0; k < 3; ++k)
+        diff[k] -= point[k];
+      r2 = diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2];
     }
     else
     {
@@ -100,8 +91,9 @@ _compute_closest_entity(const geometry::BoundingBoxTree& tree,
       if (r2 <= R2)
       {
         r2 = geometry::squared_distance(mesh, tree.tdim(),
-                                        xtl::span(&bbox[1], 1),
-                                        xt::reshape_view(point, {1, 3}))[0];
+                                        std::span(&bbox[1], 1),
+                                        {{point[0], point[1], point[2]}})
+                 .front();
       }
     }
 
@@ -136,10 +128,9 @@ _compute_closest_entity(const geometry::BoundingBoxTree& tree,
 /// @param[in] tree The bounding box tree
 /// @param[in] points The points (shape=(num_points, 3))
 /// @param[in, out] entities The list of colliding entities (local to process)
-void _compute_collisions_point(
-    const geometry::BoundingBoxTree& tree,
-    const xt::xtensor_fixed<double, xt::xshape<3>>& p,
-    std::vector<int>& entities)
+void _compute_collisions_point(const geometry::BoundingBoxTree& tree,
+                               const std::array<double, 3>& p,
+                               std::vector<int>& entities)
 {
   std::deque<std::int32_t> stack;
   int next = tree.num_bboxes() - 1;
@@ -248,7 +239,7 @@ void _compute_collisions_tree(const geometry::BoundingBoxTree& A,
 //-----------------------------------------------------------------------------
 geometry::BoundingBoxTree
 geometry::create_midpoint_tree(const mesh::Mesh& mesh, int tdim,
-                               const xtl::span<const std::int32_t>& entities)
+                               const std::span<const std::int32_t>& entities)
 {
   LOG(INFO) << "Building point search tree to accelerate distance queries for "
                "a given topological dimension and subset of entities.";
@@ -285,15 +276,17 @@ geometry::compute_collisions(const BoundingBoxTree& tree0,
 //-----------------------------------------------------------------------------
 graph::AdjacencyList<std::int32_t>
 geometry::compute_collisions(const BoundingBoxTree& tree,
-                             const xt::xtensor<double, 2>& points)
+                             const std::span<const double>& points)
 {
   if (tree.num_bboxes() > 0)
   {
-    std::vector<std::int32_t> entities, offsets(points.shape(0) + 1, 0);
-    entities.reserve(points.shape(0));
-    for (std::size_t p = 0; p < points.shape(0); ++p)
+    std::vector<std::int32_t> entities, offsets(points.size() / 3 + 1, 0);
+    entities.reserve(points.size() / 3);
+    for (std::size_t p = 0; p < points.size() / 3; ++p)
     {
-      _compute_collisions_point(tree, xt::row(points, p), entities);
+      _compute_collisions_point(
+          tree, {points[3 * p + 0], points[3 * p + 1], points[3 * p + 2]},
+          entities);
       offsets[p + 1] = entities.size();
     }
 
@@ -304,25 +297,24 @@ geometry::compute_collisions(const BoundingBoxTree& tree,
   {
     return graph::AdjacencyList<std::int32_t>(
         std::vector<std::int32_t>(),
-        std::vector<std::int32_t>(points.shape(0) + 1, 0));
+        std::vector<std::int32_t>(points.size() / 3 + 1, 0));
   }
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> geometry::compute_closest_entity(
     const BoundingBoxTree& tree, const BoundingBoxTree& midpoint_tree,
-    const mesh::Mesh& mesh, const xt::xtensor<double, 2>& points)
+    const mesh::Mesh& mesh, const std::span<const double>& points)
 {
-  assert(points.shape(1) == 3);
   if (tree.num_bboxes() == 0)
-    return std::vector<std::int32_t>(points.shape(0), -1);
+    return std::vector<std::int32_t>(points.size() / 3, -1);
   else
   {
     double R2;
     double initial_entity;
     std::array<int, 2> leaves;
     std::vector<std::int32_t> entities;
-    entities.reserve(points.shape(0));
-    for (std::size_t i = 0; i < points.shape(0); i++)
+    entities.reserve(points.size() / 3);
+    for (std::size_t i = 0; i < points.size() / 3; ++i)
     {
       // Use midpoint tree to find initial closest entity to the point.
       // Start by using a leaf node as the initial guess for the input
@@ -330,17 +322,18 @@ std::vector<std::int32_t> geometry::compute_closest_entity(
       leaves = midpoint_tree.bbox(0);
       assert(is_leaf(leaves));
       initial_entity = leaves[0];
-      xt::xtensor_fixed<double, xt::xshape<3>> diff
-          = xt::row(midpoint_tree.get_bbox(0), 0);
-      diff -= xt::row(points, i);
-      R2 = xt::norm_sq(diff)();
+      std::array<double, 3> diff = midpoint_tree.get_bbox(0)[0];
+      for (std::size_t k = 0; k < 3; ++k)
+        diff[k] -= points[3 * i + k];
+      R2 = diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2];
 
       // Use a recursive search through the bounding box tree
       // to find determine the entity with the closest midpoint.
       // As the midpoint tree only consist of points, the distance
       // queries are lightweight.
       const auto [m_index, m_distance2] = _compute_closest_entity(
-          midpoint_tree, xt::reshape_view(xt::row(points, i), {1, 3}),
+          midpoint_tree,
+          {points[3 * i + 0], points[3 * i + 1], points[3 * i + 2]},
           midpoint_tree.num_bboxes() - 1, mesh, initial_entity, R2);
 
       // Use a recursive search through the bounding box tree to
@@ -349,7 +342,7 @@ std::vector<std::int32_t> geometry::compute_closest_entity(
       // the distance from the midpoint to the point of interest as the
       // initial search radius.
       const auto [index, distance2] = _compute_closest_entity(
-          tree, xt::reshape_view(xt::row(points, i), {1, 3}),
+          tree, {points[3 * i + 0], points[3 * i + 1], points[3 * i + 2]},
           tree.num_bboxes() - 1, mesh, m_index, m_distance2);
 
       entities.push_back(index);
@@ -361,42 +354,53 @@ std::vector<std::int32_t> geometry::compute_closest_entity(
 
 //-----------------------------------------------------------------------------
 double geometry::compute_squared_distance_bbox(
-    const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
-    const xt::xtensor_fixed<double, xt::xshape<3>>& x)
+    const std::array<std::array<double, 3>, 2>& b,
+    const std::array<double, 3>& x)
 {
-  const xt::xtensor_fixed<double, xt::xshape<3>> d0 = x - xt::row(b, 0);
-  const xt::xtensor_fixed<double, xt::xshape<3>> d1 = x - xt::row(b, 1);
-  auto _d0 = xt::where(d0 > 0.0, 0, d0);
-  auto _d1 = xt::where(d1 < 0.0, 0, d1);
-  return xt::norm_sq(_d0)() + xt::norm_sq(_d1)();
+  auto& b0 = b[0];
+  auto& b1 = b[1];
+  return std::transform_reduce(x.begin(), x.end(), b0.begin(), 0.0,
+                               std::plus<>{},
+                               [](auto x, auto b)
+                               {
+                                 auto dx = x - b;
+                                 return dx > 0 ? 0 : dx * dx;
+                               })
+         + std::transform_reduce(x.begin(), x.end(), b1.begin(), 0.0,
+                                 std::plus<>{},
+                                 [](auto x, auto b)
+                                 {
+                                   auto dx = x - b;
+                                   return dx < 0 ? 0 : dx * dx;
+                                 });
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2>
+std::vector<double>
 geometry::shortest_vector(const mesh::Mesh& mesh, int dim,
-                          const xtl::span<const std::int32_t>& entities,
-                          const xt::xtensor<double, 2>& points)
+                          const std::span<const std::int32_t>& entities,
+                          const std::span<const double>& points)
 {
-  assert(points.shape(1) == 3);
   const int tdim = mesh.topology().dim();
   const mesh::Geometry& geometry = mesh.geometry();
-  xtl::span<const double> geom_dofs = geometry.x();
+  std::span<const double> geom_dofs = geometry.x();
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  xt::xtensor<double, 2> shortest_vectors({entities.size(), 3});
+  std::vector<double> shortest_vectors(3 * entities.size());
   if (dim == tdim)
   {
     for (std::size_t e = 0; e < entities.size(); e++)
     {
       auto dofs = x_dofmap.links(entities[e]);
-      xt::xtensor<double, 2> nodes({dofs.size(), 3});
+      std::vector<double> nodes(3 * dofs.size());
       for (std::size_t i = 0; i < dofs.size(); ++i)
       {
         const int pos = 3 * dofs[i];
         for (std::size_t j = 0; j < 3; ++j)
-          nodes(i, j) = geom_dofs[pos + j];
+          nodes[3 * i + j] = geom_dofs[pos + j];
       }
 
-      xt::row(shortest_vectors, e) = geometry::compute_distance_gjk(
-          xt::reshape_view(xt::row(points, e), {1, 3}), nodes);
+      std::array<double, 3> d
+          = geometry::compute_distance_gjk(points.subspan(3 * e, 3), nodes);
+      std::copy(d.begin(), d.end(), std::next(shortest_vectors.begin(), 3 * e));
     }
   }
   else
@@ -426,34 +430,40 @@ geometry::shortest_vector(const mesh::Mesh& mesh, int dim,
       const std::vector<int> entity_dofs
           = geometry.cmap().create_dof_layout().entity_closure_dofs(
               dim, local_cell_entity);
-      xt::xtensor<double, 2> nodes({entity_dofs.size(), 3});
+      std::vector<double> nodes(3 * entity_dofs.size());
       for (std::size_t i = 0; i < entity_dofs.size(); i++)
       {
         const int pos = 3 * dofs[entity_dofs[i]];
         for (std::size_t j = 0; j < 3; ++j)
-          nodes(i, j) = geom_dofs[pos + j];
+          nodes[3 * i + j] = geom_dofs[pos + j];
       }
 
-      xt::row(shortest_vectors, e) = compute_distance_gjk(
-          xt::reshape_view(xt::row(points, e), {1, 3}), nodes);
+      std::array<double, 3> d
+          = compute_distance_gjk(points.subspan(3 * e, 3), nodes);
+      std::copy(d.begin(), d.end(), std::next(shortest_vectors.begin(), 3 * e));
     }
   }
 
   return shortest_vectors;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 1>
+std::vector<double>
 geometry::squared_distance(const mesh::Mesh& mesh, int dim,
-                           const xtl::span<const std::int32_t>& entities,
-                           const xt::xtensor<double, 2>& points)
+                           const std::span<const std::int32_t>& entities,
+                           const std::span<const double>& points)
 {
-  return xt::norm_sq(shortest_vector(mesh, dim, entities, points), {1});
+  std::vector<double> v = shortest_vector(mesh, dim, entities, points);
+  std::vector<double> d(v.size() / 3, 0);
+  for (std::size_t i = 0; i < d.size(); ++i)
+    for (std::size_t j = 0; j < 3; ++j)
+      d[i] += v[3 * i + j] * v[3 * i + j];
+  return d;
 }
 //-------------------------------------------------------------------------------
 graph::AdjacencyList<std::int32_t> geometry::compute_colliding_cells(
     const mesh::Mesh& mesh,
     const graph::AdjacencyList<std::int32_t>& candidate_cells,
-    const xt::xtensor<double, 2>& points)
+    const std::span<const double>& points)
 {
   std::vector<std::int32_t> offsets = {0};
   offsets.reserve(candidate_cells.num_nodes() + 1);
@@ -463,11 +473,12 @@ graph::AdjacencyList<std::int32_t> geometry::compute_colliding_cells(
   for (std::int32_t i = 0; i < candidate_cells.num_nodes(); i++)
   {
     auto cells = candidate_cells.links(i);
-    xt::xtensor<double, 2> _point({cells.size(), 3});
-    for (std::size_t j = 0; j < cells.size(); j++)
-      xt::row(_point, j) = xt::row(points, i);
+    std::vector<double> _point(3 * cells.size());
+    for (std::size_t j = 0; j < cells.size(); ++j)
+      for (std::size_t k = 0; k < 3; ++k)
+        _point[3 * j + k] = points[3 * i + k];
 
-    xt::xtensor<double, 1> distances_sq
+    std::vector<double> distances_sq
         = geometry::squared_distance(mesh, tdim, cells, _point);
     for (std::size_t j = 0; j < cells.size(); j++)
       if (distances_sq[j] < eps2)
@@ -482,7 +493,7 @@ graph::AdjacencyList<std::int32_t> geometry::compute_colliding_cells(
 //-------------------------------------------------------------------------------
 int geometry::compute_first_colliding_cell(
     const mesh::Mesh& mesh, const geometry::BoundingBoxTree& tree,
-    const xt::xtensor_fixed<double, xt::xshape<3>>& point)
+    const std::array<double, 3>& point)
 {
   // Compute colliding bounding boxes(cell candidates)
   std::vector<std::int32_t> cell_candidates;
@@ -497,7 +508,7 @@ int geometry::compute_first_colliding_cell(
     xtl::span<const double> geom_dofs = geometry.x();
     const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
     const std::size_t num_nodes = geometry.cmap().dim();
-    xt::xtensor<double, 2> coordinate_dofs({num_nodes, std::size_t(3)});
+    std::vector<double> coordinate_dofs(num_nodes * 3);
     for (auto cell : cell_candidates)
     {
       auto dofs = x_dofmap.links(cell);
@@ -505,9 +516,8 @@ int geometry::compute_first_colliding_cell(
         common::impl::copy_N<3>(std::next(geom_dofs.begin(), 3 * dofs[i]),
                                 std::next(coordinate_dofs.begin(), 3 * i));
       // Fix
-      xt::xtensor_fixed<double, xt::xshape<3>> shortest_vector
-          = geometry::compute_distance_gjk(xt::reshape_view(point, {1, 3}),
-                                           coordinate_dofs);
+      std::array<double, 3> shortest_vector
+          = geometry::compute_distance_gjk(point, coordinate_dofs);
       double norm = 0;
       std::for_each(shortest_vector.cbegin(), shortest_vector.cend(),
                     [&norm](const double e) { norm += std::pow(e, 2); });
@@ -523,7 +533,7 @@ int geometry::compute_first_colliding_cell(
 std::tuple<std::vector<std::int32_t>, std::vector<std::int32_t>,
            std::vector<double>, std::vector<std::int32_t>>
 geometry::determine_point_ownership(const mesh::Mesh& mesh,
-                                    const xt::xtensor<double, 2>& points)
+                                    std::span<const double> points)
 {
   const MPI_Comm& comm = mesh.comm();
 
@@ -570,7 +580,7 @@ geometry::determine_point_ownership(const mesh::Mesh& mesh,
 
   // Count the number of points to send per neighbor process
   std::vector<std::int32_t> send_sizes(out_ranks.size());
-  for (std::size_t i = 0; i < points.shape(0); ++i)
+  for (std::size_t i = 0; i < points.size() / 3; ++i)
     for (const auto& p : collisions.links(i))
       send_sizes[rank_to_neighbor[p]] += 3;
 
@@ -592,16 +602,15 @@ geometry::determine_point_ownership(const mesh::Mesh& mesh,
   std::vector<std::int32_t> counter(send_sizes.size(), 0);
   // unpack map: [index in adj list][pos in x]
   std::vector<std::int32_t> unpack_map(send_offsets.back() / 3);
-  for (std::size_t i = 0; i < points.shape(0); ++i)
+  for (std::size_t i = 0; i < points.size(); i += 3)
   {
-    const auto point = xt::row(points, i);
-    for (const auto& p : collisions.links(i))
+    for (const auto& p : collisions.links(i / 3))
     {
       int neighbor = rank_to_neighbor[p];
       int pos = send_offsets[neighbor] + counter[neighbor];
       auto it = std::next(send_data.begin(), pos);
-      std::copy(point.begin(), point.end(), it);
-      unpack_map[pos / 3] = i;
+      dolfinx::common::impl::copy_N<3>(std::next(points.begin(), i), it);
+      unpack_map[pos / 3] = i / 3;
       counter[neighbor] += 3;
     }
   }
@@ -611,8 +620,7 @@ geometry::determine_point_ownership(const mesh::Mesh& mesh,
   std::partial_sum(recv_sizes.begin(), recv_sizes.end(),
                    std::next(recv_offsets.begin(), 1));
 
-  xt::xtensor<double, 2> received_points(
-      {std::size_t(recv_offsets.back() / 3), 3});
+  std::vector<double> received_points((std::size_t)recv_offsets.back());
   MPI_Neighbor_alltoallv(send_data.data(), send_sizes.data(),
                          send_offsets.data(), MPI_DOUBLE,
                          received_points.data(), recv_sizes.data(),
@@ -620,14 +628,19 @@ geometry::determine_point_ownership(const mesh::Mesh& mesh,
 
   // Each process checks which points collides with a cell on the process
   const int rank = dolfinx::MPI::rank(comm);
-  std::vector<std::int32_t> cell_indicator(received_points.shape(0));
-  std::vector<std::int32_t> colliding_cells(received_points.shape(0));
-  for (std::size_t p = 0; p < received_points.shape(0); ++p)
+  std::vector<std::int32_t> cell_indicator(received_points.size() / 3);
+  std::vector<std::int32_t> colliding_cells(received_points.size() / 3);
+  for (std::size_t p = 0; p < received_points.size(); p += 3)
   {
-    const int colliding_cell = geometry::compute_first_colliding_cell(
-        mesh, bb, xt::row(received_points, p));
-    cell_indicator[p] = (colliding_cell >= 0) ? rank : -1;
-    colliding_cells[p] = colliding_cell;
+    // NOTE: Aim to remove this by using span, see:
+    // https://github.com/FEniCS/dolfinx/issues/2284
+    std::array<double, 3> point;
+    dolfinx::common::impl::copy_N<3>(std::next(received_points.begin(), p),
+                                     point.begin());
+    const int colliding_cell
+        = geometry::compute_first_colliding_cell(mesh, bb, point);
+    cell_indicator[p / 3] = (colliding_cell >= 0) ? rank : -1;
+    colliding_cells[p / 3] = colliding_cell;
   }
   // Create neighborhood communicator in the reverse direction: send back col to
   // requesting processes
@@ -661,7 +674,7 @@ geometry::determine_point_ownership(const mesh::Mesh& mesh,
       recv_sizes.data(), recv_offsets.data(),
       dolfinx::MPI::mpi_type<std::int32_t>(), reverse_comm);
 
-  std::vector<std::int32_t> point_owners(points.shape(0), -1);
+  std::vector<std::int32_t> point_owners(points.size() / 3, -1);
   for (std::size_t i = 0; i < unpack_map.size(); i++)
   {
     const std::int32_t pos = unpack_map[i];
@@ -676,7 +689,7 @@ geometry::determine_point_ownership(const mesh::Mesh& mesh,
   // Pack ownership data
   std::vector<std::int32_t> send_owners(send_offsets.back());
   std::fill(counter.begin(), counter.end(), 0);
-  for (std::size_t i = 0; i < points.shape(0); ++i)
+  for (std::size_t i = 0; i < points.size() / 3; ++i)
   {
     for (const auto& p : collisions.links(i))
     {
@@ -706,9 +719,9 @@ geometry::determine_point_ownership(const mesh::Mesh& mesh,
       if (rank == dest_ranks[j])
       {
         owned_recv_ranks.push_back(in_ranks[i]);
-        auto point = xt::row(received_points, j);
-        owned_recv_points.insert(owned_recv_points.end(), point.cbegin(),
-                                 point.cend());
+        owned_recv_points.insert(
+            owned_recv_points.end(), std::next(received_points.cbegin(), 3 * j),
+            std::next(received_points.cbegin(), 3 * (j + 1)));
         owned_recv_cells.push_back(colliding_cells[j]);
       }
     }

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -7,12 +7,10 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <dolfinx/graph/AdjacencyList.h>
+#include <span>
 #include <vector>
-#include <xtensor/xfixed.hpp>
-#include <xtensor/xshape.hpp>
-#include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::mesh
 {
@@ -31,7 +29,7 @@ class BoundingBoxTree;
 /// @return Bounding box tree for midpoints of mesh entities
 BoundingBoxTree
 create_midpoint_tree(const mesh::Mesh& mesh, int tdim,
-                     const xtl::span<const std::int32_t>& entity_indices);
+                     const std::span<const std::int32_t>& entity_indices);
 
 /// Compute all collisions between two BoundingBoxTrees (local to
 /// process)
@@ -44,12 +42,13 @@ compute_collisions(const BoundingBoxTree& tree0, const BoundingBoxTree& tree1);
 /// Compute all collisions between bounding boxes and for a set of
 /// points
 /// @param[in] tree The bounding box tree
-/// @param[in] points The points (shape=(num_points, 3))
+/// @param[in] points The points (shape=(num_points, 3)). Storage
+/// is row-major.
 /// @return An adjacency list where the ith node corresponds to the
 /// bounding box leaves that contain the ith point
 graph::AdjacencyList<std::int32_t>
 compute_collisions(const BoundingBoxTree& tree,
-                   const xt::xtensor<double, 2>& points);
+                   const std::span<const double>& points);
 
 /// Compute the first collision between a point and
 /// the cells of the mesh
@@ -57,43 +56,46 @@ compute_collisions(const BoundingBoxTree& tree,
 /// @param[in] tree The bounding box tree
 /// @param[in] point The point (shape=(3))
 /// @return The local cell index, -1 if not found
-int compute_first_colliding_cell(
-    const mesh::Mesh& mesh, const BoundingBoxTree& tree,
-    const xt::xtensor_fixed<double, xt::xshape<3>>& point);
+int compute_first_colliding_cell(const mesh::Mesh& mesh,
+                                 const BoundingBoxTree& tree,
+                                 const std::array<double, 3>& point);
 
 /// Compute closest mesh entity to a point
 /// @param[in] tree The bounding box tree for the entities
 /// @param[in] midpoint_tree A bounding box tree with the midpoints of
 /// all the mesh entities. This is used to accelerate the search
 /// @param[in] mesh The mesh
-/// @param[in] points The set of points (shape=(num_points, 3))
+/// @param[in] points The set of points (shape=(num_points, 3)). Storage
+/// is row-major.
 /// @return Index of the closest mesh entity to a point. The ith entry
 /// is the index of the closest entity to the ith input point.
 /// @note Returns index -1 if the bounding box tree is empty
 std::vector<std::int32_t> compute_closest_entity(
     const BoundingBoxTree& tree, const BoundingBoxTree& midpoint_tree,
-    const mesh::Mesh& mesh, const xt::xtensor<double, 2>& points);
+    const mesh::Mesh& mesh, const std::span<const double>& points);
 
 /// Compute squared distance between point and bounding box
 /// @param[in] b Bounding box coordinates
 /// @param[in] x A point
 /// @return The shortest distance between the bounding box `b` and the
 /// point `x`. Returns zero if `x` is inside box.
-double compute_squared_distance_bbox(
-    const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
-    const xt::xtensor_fixed<double, xt::xshape<3>>& x);
+double
+compute_squared_distance_bbox(const std::array<std::array<double, 3>, 2>& b,
+                              const std::array<double, 3>& x);
 
 /// Compute the shortest vector from a mesh entity to a point
 /// @param[in] mesh The mesh
 /// @param[in] dim The topological dimension of the mesh entity
 /// @param[in] entities The list of entities (local to process)
-/// @param[in] points The set of points (shape=(num_points, 3))
-/// @return An array of vectors where the ith row is the shortest vector
-/// from the ith entity and the ith point
-xt::xtensor<double, 2>
+/// @param[in] points The set of points (shape=(num_points, 3)), using row-major
+/// storage
+/// @return An array of vectors (shape=(num_points, 3)) where the ith
+/// row is the shortest vector between the ith entity and the ith point.
+/// Storage is row-major.
+std::vector<double>
 shortest_vector(const mesh::Mesh& mesh, int dim,
-                const xtl::span<const std::int32_t>& entities,
-                const xt::xtensor<double, 2>& points);
+                const std::span<const std::int32_t>& entities,
+                const std::span<const double>& points);
 
 /// Compute the squared distance between a point and a mesh entity. The
 /// distance is computed between the ith input points and the ith input
@@ -105,12 +107,12 @@ shortest_vector(const mesh::Mesh& mesh, int dim,
 /// @param[in] dim The topological dimension of the mesh entities
 /// @param[in] entities The indices of the mesh entities (local to process)
 /// @param[in] points The set points from which to computed the shortest
-/// (shape=(num_points, 3))
+/// (shape=(num_points, 3)). Storage is row-major.
 /// @return Squared shortest distance from points[i] to entities[i]
-xt::xtensor<double, 1>
+std::vector<double>
 squared_distance(const mesh::Mesh& mesh, int dim,
-                 const xtl::span<const std::int32_t>& entities,
-                 const xt::xtensor<double, 2>& points);
+                 const std::span<const std::int32_t>& entities,
+                 const std::span<const double>& points);
 
 /// From a Mesh, find which cells collide with a set of points.
 /// @note Uses the GJK algorithm, see geometry::compute_distance_gjk for
@@ -119,19 +121,20 @@ squared_distance(const mesh::Mesh& mesh, int dim,
 /// @param[in] candidate_cells List of candidate colliding cells for the
 /// ith point in `points`
 /// @param[in] points The points to check for collision
-/// (shape=(num_points, 3))
+/// (shape=(num_points, 3)). Storage is row-major.
 /// @return Adjacency list where the ith node is the list of entities
 /// that collide with the ith point
 /// @note There may be nodes with no entries in the adjacency list
 graph::AdjacencyList<int> compute_colliding_cells(
     const mesh::Mesh& mesh,
     const graph::AdjacencyList<std::int32_t>& candidate_cells,
-    const xt::xtensor<double, 2>& points);
+    const std::span<const double>& points);
 
 /// Given a set of points (local on each process) which process is colliding,
 /// using the GJK algorithm on cells to determine collisions.
 /// @param[in] mesh The mesh
-/// @param[in] points The points to check for collision (shape=(num_points, 3))
+/// @param[in] points The points to check for collision (shape=(num_points, 3)).
+/// Storage is row-major.
 /// @return Quadratuplet (src_owner, dest_owner, dest_points, dest_cells), where
 /// src_owner is a list of ranks corresponding to the input points. dest_owner
 /// is a list of ranks corresponding to dest_points, the points that this
@@ -144,6 +147,6 @@ graph::AdjacencyList<int> compute_colliding_cells(
 std::tuple<std::vector<std::int32_t>, std::vector<std::int32_t>,
            std::vector<double>, std::vector<std::int32_t>>
 determine_point_ownership(const mesh::Mesh& mesh,
-                          const xt::xtensor<double, 2>& points);
+                          std::span<const double> points);
 
 } // namespace dolfinx::geometry

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -164,12 +164,13 @@ private:
 /// @brief Construct a constant degree (valency) adjacency list.
 ///
 /// A constant degree graph has the same number of edges for every node.
+///
 /// @param [in] data Adjacency array
 /// @param [in] degree The number of (outgoing) edges for each node
 /// @return An adjacency list
 template <typename U>
-AdjacencyList<typename U::value_type> regular_adjacency_list(U&& data,
-                                                             int degree)
+AdjacencyList<typename std::decay_t<U>::value_type>
+regular_adjacency_list(U&& data, int degree)
 {
   if (degree == 0 and !data.empty())
   {
@@ -187,8 +188,8 @@ AdjacencyList<typename U::value_type> regular_adjacency_list(U&& data,
   std::vector<std::int32_t> offsets(num_nodes + 1, 0);
   for (std::size_t i = 1; i < offsets.size(); ++i)
     offsets[i] = offsets[i - 1] + degree;
-  return AdjacencyList<typename U::value_type>(std::forward<U>(data),
-                                               std::move(offsets));
+  return AdjacencyList<typename std::decay_t<U>::value_type>(
+      std::forward<U>(data), std::move(offsets));
 }
 
 } // namespace dolfinx::graph

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -8,33 +8,13 @@
 
 #include <cassert>
 #include <numeric>
+#include <span>
 #include <sstream>
 #include <utility>
 #include <vector>
-#include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::graph
 {
-
-/// Construct adjacency list data for a problem with a fixed number of
-/// links (edges) for each node
-/// @param [in] array Two-dimensional array of adjacency data where
-/// matrix(i, j) is the jth neighbor of the ith node
-/// @return Adjacency list data and offset array
-template <typename T>
-auto create_adjacency_data(const xt::xtensor<T, 2>& array)
-{
-  std::vector<T> data(array.shape(0) * array.shape(1));
-  std::vector<std::int32_t> offset(array.shape(0) + 1, 0);
-  for (std::size_t i = 0; i < array.shape(0); ++i)
-  {
-    for (std::size_t j = 0; j < array.shape(1); ++j)
-      data[i * array.shape(1) + j] = array(i, j);
-    offset[i + 1] = offset[i] + array.shape(1);
-  }
-  return std::pair(std::move(data), std::move(offset));
-}
 
 /// This class provides a static adjacency list data structure. It is
 /// commonly used to store directed graphs. For each node in the
@@ -128,9 +108,9 @@ public:
   /// @param [in] node Node index
   /// @return Array of outgoing links for the node. The length will be
   /// AdjacencyList::num_links(node).
-  xtl::span<T> links(int node)
+  std::span<T> links(int node)
   {
-    return xtl::span<T>(_array.data() + _offsets[node],
+    return std::span<T>(_array.data() + _offsets[node],
                         _offsets[node + 1] - _offsets[node]);
   }
 
@@ -138,9 +118,9 @@ public:
   /// @param [in] node Node index
   /// @return Array of outgoing links for the node. The length will be
   /// AdjacencyList:num_links(node).
-  xtl::span<const T> links(int node) const
+  std::span<const T> links(int node) const
   {
-    return xtl::span<const T>(_array.data() + _offsets[node],
+    return std::span<const T>(_array.data() + _offsets[node],
                               _offsets[node + 1] - _offsets[node]);
   }
 

--- a/cpp/dolfinx/graph/ordering.cpp
+++ b/cpp/dolfinx/graph/ordering.cpp
@@ -21,7 +21,7 @@ namespace
 // contain the nodes in "indices".
 std::vector<std::vector<int>>
 residual_graph_components(const graph::AdjacencyList<int>& graph,
-                          const xtl::span<const int>& indices)
+                          const std::span<const int>& indices)
 {
   if (indices.empty())
     return std::vector<std::vector<int>>();
@@ -125,7 +125,7 @@ create_level_structure(const graph::AdjacencyList<int>& graph, int s)
 // with -1 in the vector rlabel).
 std::vector<std::int32_t>
 gps_reorder_unlabelled(const graph::AdjacencyList<std::int32_t>& graph,
-                       const xtl::span<const std::int32_t>& rlabel)
+                       const std::span<const std::int32_t>& rlabel)
 {
   common::Timer timer("Gibbs-Poole-Stockmeyer ordering");
 

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -131,7 +131,7 @@ graph::build::distribute(MPI_Comm comm,
       const std::array<int, 3>& dest_data = dest_to_index[i];
       const std::size_t pos = dest_data[1];
 
-      xtl::span b(send_buffer.data() + i * buffer_shape1, buffer_shape1);
+      std::span b(send_buffer.data() + i * buffer_shape1, buffer_shape1);
       auto row = list.links(pos);
       std::copy(row.begin(), row.end(), b.begin());
 
@@ -181,7 +181,7 @@ graph::build::distribute(MPI_Comm comm,
     const int src_rank = src[p];
     for (std::int32_t i = recv_disp[p]; i < recv_disp[p + 1]; ++i)
     {
-      xtl::span row(recv_buffer.data() + i * buffer_shape1, buffer_shape1);
+      std::span row(recv_buffer.data() + i * buffer_shape1, buffer_shape1);
       auto info = row.last(3);
       std::size_t num_edges = info[0];
       int owner = info[1];
@@ -225,9 +225,9 @@ graph::build::distribute(MPI_Comm comm,
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int64_t> graph::build::compute_ghost_indices(
-    MPI_Comm comm, const xtl::span<const std::int64_t>& owned_indices,
-    const xtl::span<const std::int64_t>& ghost_indices,
-    const xtl::span<const int>& ghost_owners)
+    MPI_Comm comm, const std::span<const std::int64_t>& owned_indices,
+    const std::span<const std::int64_t>& ghost_indices,
+    const std::span<const int>& ghost_owners)
 {
   LOG(INFO) << "Compute ghost indices";
 
@@ -405,8 +405,8 @@ std::vector<std::int64_t> graph::build::compute_local_to_global_links(
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> graph::build::compute_local_to_local(
-    const xtl::span<const std::int64_t>& local0_to_global,
-    const xtl::span<const std::int64_t>& local1_to_global)
+    const std::span<const std::int64_t>& local0_to_global,
+    const std::span<const std::int64_t>& local1_to_global)
 {
   common::Timer timer("Compute local-to-local map");
   assert(local0_to_global.size() == local1_to_global.size());

--- a/cpp/dolfinx/graph/partition.h
+++ b/cpp/dolfinx/graph/partition.h
@@ -11,9 +11,9 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <functional>
 #include <mpi.h>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 #include <iostream>
 
@@ -95,9 +95,9 @@ distribute(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& list,
 /// @return New global indices for the ghost indices.
 std::vector<std::int64_t>
 compute_ghost_indices(MPI_Comm comm,
-                      const xtl::span<const std::int64_t>& owned_indices,
-                      const xtl::span<const std::int64_t>& ghost_indices,
-                      const xtl::span<const int>& ghost_owners);
+                      const std::span<const std::int64_t>& owned_indices,
+                      const std::span<const std::int64_t>& ghost_indices,
+                      const std::span<const int>& ghost_owners);
 
 /// Given an adjacency list with global, possibly non-contiguous, link
 /// indices and a local adjacency list with contiguous link indices
@@ -122,8 +122,8 @@ compute_local_to_global_links(const graph::AdjacencyList<std::int64_t>& global,
 /// indices
 /// @return Map from local0 indices to local1 indices
 std::vector<std::int32_t>
-compute_local_to_local(const xtl::span<const std::int64_t>& local0_to_global,
-                       const xtl::span<const std::int64_t>& local1_to_global);
+compute_local_to_local(const std::span<const std::int64_t>& local0_to_global,
+                       const std::span<const std::int64_t>& local1_to_global);
 } // namespace build
 
 } // namespace dolfinx::graph

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -21,7 +21,6 @@
 #include <dolfinx/mesh/utils.h>
 #include <pugixml.hpp>
 #include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::io;
@@ -91,7 +90,7 @@ void vtx_write_data(adios2::IO& io, adios2::Engine& engine,
 {
   // Get function data array and information about layout
   assert(u.x());
-  xtl::span<const T> u_vector = u.x()->array();
+  std::span<const T> u_vector = u.x()->array();
   const int rank = u.function_space()->element()->value_shape().size();
   const std::uint32_t num_comp = std::pow(3, rank);
   std::shared_ptr<const fem::DofMap> dofmap = u.function_space()->dofmap();
@@ -164,33 +163,33 @@ void vtx_write_mesh(adios2::IO& io, adios2::Engine& engine,
       io, "NumberOfNodes", {adios2::LocalValueDim});
   engine.Put<std::uint32_t>(vertices, num_vertices);
 
+  const auto [vtkcells, shape] = io::extract_vtk_connectivity(mesh);
+
   // Add cell metadata
   const int tdim = topology.dim();
-  const std::uint32_t num_cells = topology.index_map(tdim)->size_local()
-                                  + topology.index_map(tdim)->num_ghosts();
   adios2::Variable<std::uint32_t> cell_variable
       = define_variable<std::uint32_t>(io, "NumberOfCells",
                                        {adios2::LocalValueDim});
-  engine.Put<std::uint32_t>(cell_variable, num_cells);
+  engine.Put<std::uint32_t>(cell_variable, shape[0]);
   adios2::Variable<std::uint32_t> celltype_variable
       = define_variable<std::uint32_t>(io, "types");
   engine.Put<std::uint32_t>(
       celltype_variable, cells::get_vtk_cell_type(topology.cell_type(), tdim));
 
-  // Get DOLFINx to VTK permutation
-  const std::uint32_t num_nodes = geometry.cmap().dim();
-
   // Pack mesh 'nodes'. Output is written as [N0, v0_0,...., v0_N0, N1,
   // v1_0,...., v1_N1,....], where N is the number of cell nodes and v0,
   // etc, is the node index
-  xt::xtensor<std::int64_t, 2> cells({num_cells, num_nodes + 1});
-  xt::view(cells, xt::all(), xt::xrange(std::size_t(1), cells.shape(1)))
-      = io::extract_vtk_connectivity(mesh);
-  xt::view(cells, xt::all(), 0) = num_nodes;
+  std::vector<std::int64_t> cells(shape[0] * (shape[1] + 1), shape[1]);
+  for (std::size_t c = 0; c < shape[0]; ++c)
+  {
+    std::span vtkcell(vtkcells.data() + c * shape[1], shape[1]);
+    std::span cell(cells.data() + c * (shape[1] + 1), shape[1] + 1);
+    std::copy(vtkcell.begin(), vtkcell.end(), std::next(cell.begin()));
+  }
 
   // Put topology (nodes)
   adios2::Variable<std::int64_t> local_topology = define_variable<std::int64_t>(
-      io, "connectivity", {}, {}, {num_cells, num_nodes + 1});
+      io, "connectivity", {}, {}, {shape[0], shape[1] + 1});
   engine.Put<std::int64_t>(local_topology, cells.data());
 
   // Vertex global ids and ghost markers
@@ -223,31 +222,32 @@ void vtx_write_mesh_from_space(adios2::IO& io, adios2::Engine& engine,
   const int tdim = mesh->topology().dim();
 
   // Get a VTK mesh with points at the 'nodes'
-  const auto [x, x_id, x_ghost, vtk] = io::vtk_mesh_from_space(V);
+  const auto [x, xshape, x_id, x_ghost, vtk, vtkshape]
+      = io::vtk_mesh_from_space(V);
 
-  std::uint32_t num_dofs = x.shape(0);
-  std::uint32_t num_cells = mesh->topology().index_map(tdim)->size_local();
+  std::uint32_t num_dofs = xshape[0];
 
   // -- Pack mesh 'nodes'. Output is written as [N0, v0_0,...., v0_N0, N1,
   // v1_0,...., v1_N1,....], where N is the number of cell nodes and v0,
   // etc, is the node index.
-  std::vector<std::size_t> shape = {num_cells, vtk.shape(1) + 1};
 
   // Create vector, setting all entries to nodes per cell (vtk.shape(1))
-  std::vector<std::uint64_t> vtk_topology(shape[0] * shape[1], vtk.shape(1));
+  std::vector<std::int64_t> cells(vtkshape[0] * (vtkshape[1] + 1), vtkshape[1]);
 
   // Set the [v0_0,...., v0_N0, v1_0,...., v1_N1,....] data
-  auto _vtk = xt::adapt(vtk_topology, shape);
-  xt::view(_vtk, xt::all(), xt::range(1, _vtk.shape(1)))
-      = xt::view(vtk, xt::range(0, num_cells, xt::all()));
+  for (std::size_t c = 0; c < vtkshape[0]; ++c)
+  {
+    std::span vtkcell(vtk.data() + c * vtkshape[1], vtkshape[1]);
+    std::span cell(cells.data() + c * (vtkshape[1] + 1), vtkshape[1] + 1);
+    std::copy(vtkcell.begin(), vtkcell.end(), std::next(cell.begin()));
+  }
 
   // Define ADIOS2 variables for geometry, topology, celltypes and
   // corresponding VTK data
   adios2::Variable<double> local_geometry
       = define_variable<double>(io, "geometry", {}, {}, {num_dofs, 3});
-  adios2::Variable<std::uint64_t> local_topology
-      = define_variable<std::uint64_t>(io, "connectivity", {}, {},
-                                       {num_cells, vtk.shape(1) + 1});
+  adios2::Variable<std::int64_t> local_topology = define_variable<std::int64_t>(
+      io, "connectivity", {}, {}, {vtkshape[0], vtkshape[1] + 1});
   adios2::Variable<std::uint32_t> cell_type
       = define_variable<std::uint32_t>(io, "types");
   adios2::Variable<std::uint32_t> vertices = define_variable<std::uint32_t>(
@@ -257,11 +257,11 @@ void vtx_write_mesh_from_space(adios2::IO& io, adios2::Engine& engine,
 
   // Write mesh information to file
   engine.Put<std::uint32_t>(vertices, num_dofs);
-  engine.Put<std::uint32_t>(elements, num_cells);
+  engine.Put<std::uint32_t>(elements, vtkshape[0]);
   engine.Put<std::uint32_t>(
       cell_type, cells::get_vtk_cell_type(mesh->topology().cell_type(), tdim));
   engine.Put<double>(local_geometry, x.data());
-  engine.Put<std::uint64_t>(local_topology, vtk_topology.data());
+  engine.Put<std::int64_t>(local_topology, cells.data());
 
   // Node global ids
   adios2::Variable<std::int64_t> orig_id = define_variable<std::int64_t>(
@@ -471,14 +471,14 @@ void fides_write_data(adios2::IO& io, adios2::Engine& engine,
 
   // Get vertex data. If the mesh and function dofmaps are the same we
   // can work directly with the dof array.
-  xtl::span<const T> data;
+  std::span<const T> data;
   std::vector<T> _data;
   if (mesh->geometry().dofmap() == dofmap->list() and !need_padding)
     data = u.x()->array();
   else
   {
     _data = pack_function_data(u);
-    data = xtl::span<const T>(_data);
+    data = std::span<const T>(_data);
   }
 
   auto vertex_map = mesh->topology().index_map(0);
@@ -509,13 +509,13 @@ void fides_write_data(adios2::IO& io, adios2::Engine& engine,
 
     adios2::Variable<U> local_output_r = define_variable<U>(
         io, u.name + field_ext[0], {}, {}, {num_vertices, num_components});
-    std::transform(data.cbegin(), data.cend(), data_real.begin(),
+    std::transform(data.begin(), data.end(), data_real.begin(),
                    [](auto& x) -> U { return std::real(x); });
     engine.Put<U>(local_output_r, data_real.data());
 
     adios2::Variable<U> local_output_c = define_variable<U>(
         io, u.name + field_ext[1], {}, {}, {num_vertices, num_components});
-    std::transform(data.cbegin(), data.cend(), data_imag.begin(),
+    std::transform(data.begin(), data.end(), data_imag.begin(),
                    [](auto& x) -> U { return std::imag(x); });
     engine.Put<U>(local_output_c, data_imag.data());
     engine.PerformPuts();
@@ -548,7 +548,7 @@ void fides_write_mesh(adios2::IO& io, adios2::Engine& engine,
   const int tdim = topology.dim();
   const std::int32_t num_cells = topology.index_map(tdim)->size_local();
   const int num_nodes = geometry.cmap().dim();
-  const xt::xtensor<std::int64_t, 2> cells = extract_vtk_connectivity(mesh);
+  const auto [cells, shape] = io::extract_vtk_connectivity(mesh);
 
   // "Put" topology data in the result in the ADIOS2 file
   adios2::Variable<std::int64_t> local_topology = define_variable<std::int64_t>(

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -20,7 +20,6 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/utils.h>
 #include <pugixml.hpp>
-#include <xtensor/xtensor.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::io;

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -20,12 +20,9 @@
 #include <filesystem>
 #include <iterator>
 #include <pugixml.hpp>
+#include <span>
 #include <sstream>
 #include <string>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xcomplex.hpp>
-#include <xtensor/xview.hpp>
-#include <xtl/xspan.hpp>
 
 using namespace dolfinx;
 
@@ -131,7 +128,7 @@ void add_pvtu_mesh(pugi::xml_node& node)
 /// @param[in,out] data_node The XML node to add data to
 template <typename T>
 void add_data_float(const std::string& name, int rank,
-                    const xtl::span<const T>& values, pugi::xml_node& node)
+                    const std::span<const T>& values, pugi::xml_node& node)
 {
   static_assert(std::is_floating_point_v<T>, "Scalar must be a float");
 
@@ -163,7 +160,7 @@ void add_data_float(const std::string& name, int rank,
 /// @param[in,out] data_node The XML node to add data to
 template <typename T>
 void add_data(const std::string& name, int rank,
-              const xtl::span<const T>& values, pugi::xml_node& node)
+              const std::span<const T>& values, pugi::xml_node& node)
 {
   if constexpr (std::is_scalar_v<T>)
     add_data_float(name, rank, values, node);
@@ -172,20 +169,21 @@ void add_data(const std::string& name, int rank,
     using U = typename T::value_type;
     std::vector<U> v(values.size());
 
-    std::transform(values.cbegin(), values.cend(), v.begin(),
+    std::transform(values.begin(), values.end(), v.begin(),
                    [](auto x) { return x.real(); });
-    add_data_float(name + field_ext[0], rank, xtl::span<const U>(v), node);
+    add_data_float(name + field_ext[0], rank, std::span<const U>(v), node);
 
-    std::transform(values.cbegin(), values.cend(), v.begin(),
+    std::transform(values.begin(), values.end(), v.begin(),
                    [](auto x) { return x.imag(); });
-    add_data_float(name + field_ext[1], rank, xtl::span<const U>(v), node);
+    add_data_float(name + field_ext[1], rank, std::span<const U>(v), node);
   }
 }
 //----------------------------------------------------------------------------
 
 /// Add mesh geometry and topology data to a pugixml node. This function
 /// adds the Points and Cells nodes to the input node.
-/// @param[in] x Coordinates of the points
+/// @param[in] x Coordinates of the points, row-major storage
+/// @param[in] xshape The shape of `x`
 /// @param[in] x_id Unique global index for each point
 /// @param[in] x_ghost Flag indicating if a point is a owned (0) or is a
 /// ghost (1)
@@ -194,10 +192,12 @@ void add_data(const std::string& name, int rank,
 /// @param[in] celltype The cell type
 /// @param[in] tdim Topological dimension of the cells
 /// @param[in,out] piece_node The XML node to add data to
-void add_mesh(const xt::xtensor<double, 2>& x,
-              const xtl::span<const std::int64_t> x_id,
-              const xtl::span<const std::uint8_t> x_ghost,
-              const xt::xtensor<std::int64_t, 2>& cells,
+void add_mesh(const std::span<const double>& x,
+              std::array<std::size_t, 2> /*xshape*/,
+              const std::span<const std::int64_t> x_id,
+              const std::span<const std::uint8_t> x_ghost,
+              const std::span<const std::int64_t>& cells,
+              std::array<std::size_t, 2> cshape,
               const common::IndexMap& cellmap, mesh::CellType celltype,
               int tdim, pugi::xml_node& piece_node)
 {
@@ -232,8 +232,8 @@ void add_mesh(const xt::xtensor<double, 2>& x,
   offsets_node.append_attribute("format") = "ascii";
   {
     std::stringstream ss;
-    int num_nodes = cells.shape(1);
-    for (std::size_t i = 0; i < cells.shape(0); ++i)
+    int num_nodes = cshape[1];
+    for (std::size_t i = 0; i < cshape[0]; ++i)
       ss << (i + 1) * num_nodes << " ";
     offsets_node.append_child(pugi::node_pcdata).set_value(ss.str().c_str());
   }
@@ -245,7 +245,7 @@ void add_mesh(const xt::xtensor<double, 2>& x,
   int vtk_celltype = io::cells::get_vtk_cell_type(celltype, tdim);
   {
     std::stringstream ss;
-    for (std::size_t c = 0; c < cells.shape(0); ++c)
+    for (std::size_t c = 0; c < cshape[0]; ++c)
       ss << vtk_celltype << " ";
     type_node.append_child(pugi::node_pcdata).set_value(ss.str().c_str());
   }
@@ -263,7 +263,7 @@ void add_mesh(const xt::xtensor<double, 2>& x,
     std::stringstream ss;
     for (std::int32_t c = 0; c < cellmap.size_local(); ++c)
       ss << 0 << " ";
-    for (std::size_t c = cellmap.size_local(); c < cells.shape(0); ++c)
+    for (std::size_t c = cellmap.size_local(); c < cshape[0]; ++c)
       ss << 1 << " ";
     ghost_cell_node.append_child(pugi::node_pcdata).set_value(ss.str().c_str());
   }
@@ -411,34 +411,40 @@ void write_function(
   pugi::xml_node grid_node_vtu = vtk_node_vtu.append_child("UnstructuredGrid");
 
   // Build mesh data using first FunctionSpace
-  xt::xtensor<double, 2> x;
+  std::vector<double> x;
+  std::array<std::size_t, 2> xshape;
   std::vector<std::int64_t> x_id;
   std::vector<std::uint8_t> x_ghost;
-  xt::xtensor<std::int32_t, 2> cells;
+  std::vector<std::int64_t> cells;
+  std::array<std::size_t, 2> cshape;
   if (is_cellwise(*V0))
   {
-    cells = io::extract_vtk_connectivity(*mesh0);
+    std::vector<std::int64_t> tmp;
+    std::tie(tmp, cshape) = io::extract_vtk_connectivity(*mesh0);
+    cells.assign(tmp.begin(), tmp.end());
     const mesh::Geometry& geometry = mesh0->geometry();
-    x = xt::adapt(geometry.x().data(), geometry.x().size(), xt::no_ownership(),
-                  std::vector({geometry.x().size() / 3, std::size_t(3)}));
+    x.assign(geometry.x().begin(), geometry.x().end());
+    xshape = {geometry.x().size() / 3, 3};
     x_id = geometry.input_global_indices();
     auto xmap = geometry.index_map();
     assert(xmap);
-    x_ghost.resize(x.shape(0), 0);
+    x_ghost.resize(xshape[0], 0);
     std::fill(std::next(x_ghost.begin(), xmap->size_local()), x_ghost.end(), 1);
   }
   else
-    std::tie(x, x_id, x_ghost, cells) = io::vtk_mesh_from_space(*V0);
+    std::tie(x, xshape, x_id, x_ghost, cells, cshape)
+        = io::vtk_mesh_from_space(*V0);
 
   // Add "Piece" node and required metadata
   pugi::xml_node piece_node = grid_node_vtu.append_child("Piece");
-  piece_node.append_attribute("NumberOfPoints") = x.shape(0);
-  piece_node.append_attribute("NumberOfCells") = cells.shape(0);
+  piece_node.append_attribute("NumberOfPoints") = xshape[0];
+  piece_node.append_attribute("NumberOfCells") = cshape[0];
 
   // Add mesh data to "Piece" node
   int tdim = mesh0->topology().dim();
-  add_mesh(x, x_id, x_ghost, cells, *mesh0->topology().index_map(tdim),
-           mesh0->topology().cell_type(), mesh0->topology().dim(), piece_node);
+  add_mesh(x, xshape, x_id, x_ghost, cells, cshape,
+           *mesh0->topology().index_map(tdim), mesh0->topology().cell_type(),
+           mesh0->topology().dim(), piece_node);
 
   // FIXME: is this actually setting the first?
   // Set last scalar/vector/tensor Functions in u to be the 'active'
@@ -475,17 +481,17 @@ void write_function(
       assert(!data_node.empty());
       auto dofmap = V->dofmap();
       int bs = dofmap->bs();
-      std::vector<T> data(cells.shape(0) * num_comp, 0);
+      std::vector<T> data(cshape[0] * num_comp, 0);
       auto u_vector = _u.get().x()->array();
-      for (std::size_t c = 0; c < cells.shape(0); ++c)
+      for (std::size_t c = 0; c < cshape[0]; ++c)
       {
-        xtl::span<const std::int32_t> dofs = dofmap->cell_dofs(c);
+        std::span<const std::int32_t> dofs = dofmap->cell_dofs(c);
         for (std::size_t i = 0; i < dofs.size(); ++i)
           for (int k = 0; k < bs; ++k)
             data[num_comp * c + k] = u_vector[bs * dofs[i] + k];
       }
 
-      add_data(_u.get().name, rank, xtl::span<const T>(data), data_node);
+      add_data(_u.get().name, rank, std::span<const T>(data), data_node);
     }
     else
     {
@@ -497,7 +503,7 @@ void write_function(
       // Function to pack data to 3D with 'zero' padding, typically when
       // a Function is 2D
       auto pad_data
-          = [num_comp](const fem::FunctionSpace& V, const xtl::span<const T>& u)
+          = [num_comp](const fem::FunctionSpace& V, const std::span<const T>& u)
       {
         auto dofmap = V.dofmap();
         int bs = dofmap->bs();
@@ -508,7 +514,7 @@ void write_function(
         std::vector<T> data(num_dofs_block * num_comp, 0);
         for (int i = 0; i < num_dofs_block; ++i)
         {
-          std::copy_n(std::next(u.cbegin(), i * map_bs), map_bs,
+          std::copy_n(std::next(u.begin(), i * map_bs), map_bs,
                       std::next(data.begin(), i * num_comp));
         }
 
@@ -524,7 +530,7 @@ void write_function(
         {
           // Pad with zeros and then add
           auto data = pad_data(*V, _u.get().x()->array());
-          add_data(_u.get().name, rank, xtl::span<const T>(data), data_node);
+          add_data(_u.get().name, rank, std::span<const T>(data), data_node);
         }
       }
       else if (*element == *element0)
@@ -541,10 +547,10 @@ void write_function(
         // Interpolate on each cell
         auto u_vector = _u.get().x()->array();
         std::vector<T> u(u_vector.size());
-        for (std::size_t c = 0; c < cells.shape(0); ++c)
+        for (std::size_t c = 0; c < cshape[0]; ++c)
         {
-          xtl::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
-          xtl::span<const std::int32_t> dofs = dofmap->cell_dofs(c);
+          std::span<const std::int32_t> dofs0 = dofmap0->cell_dofs(c);
+          std::span<const std::int32_t> dofs = dofmap->cell_dofs(c);
           for (std::size_t i = 0; i < dofs0.size(); ++i)
           {
             for (int k = 0; k < bs; ++k)
@@ -558,12 +564,12 @@ void write_function(
 
         // Pack/add data
         if (mesh0->geometry().dim() == 3)
-          add_data(_u.get().name, rank, xtl::span<const T>(u), data_node);
+          add_data(_u.get().name, rank, std::span<const T>(u), data_node);
         else
         {
           // Pad with zeros and then add
           auto data = pad_data(*V, _u.get().x()->array());
-          add_data(_u.get().name, rank, xtl::span<const T>(data), data_node);
+          add_data(_u.get().name, rank, std::span<const T>(data), data_node);
         }
       }
       else
@@ -765,15 +771,13 @@ void io::VTKFile::write(const mesh::Mesh& mesh, double time)
   piece_node.append_attribute("NumberOfCells") = num_cells;
 
   // Add mesh data to "Piece" node
-  xt::xtensor<std::int64_t, 2> cells = extract_vtk_connectivity(mesh);
-  xt::xtensor<double, 2> x
-      = xt::adapt(geometry.x().data(), geometry.x().size(), xt::no_ownership(),
-                  std::vector({geometry.x().size() / 3, std::size_t(3)}));
-  std::vector<std::uint8_t> x_ghost(x.shape(0), 0);
+  const auto [cells, cshape] = extract_vtk_connectivity(mesh);
+  std::array<std::size_t, 2> xshape = {geometry.x().size() / 3, 3};
+  std::vector<std::uint8_t> x_ghost(xshape[0], 0);
   std::fill(std::next(x_ghost.begin(), xmap->size_local()), x_ghost.end(), 1);
-  add_mesh(x, geometry.input_global_indices(), x_ghost, cells,
-           *topology.index_map(tdim), topology.cell_type(), topology.dim(),
-           piece_node);
+  add_mesh(geometry.x(), xshape, geometry.input_global_indices(), x_ghost,
+           cells, cshape, *topology.index_map(tdim), topology.cell_type(),
+           topology.dim(), piece_node);
 
   // Create filepath for a .vtu file
   auto create_vtu_path = [file_root = _filename.parent_path(),

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -231,26 +231,24 @@ mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
                                const std::string xpath) const
 {
   // Read mesh data
-  const xt::xtensor<std::int64_t, 2> cells
-      = XDMFFile::read_topology_data(name, xpath);
-  const xt::xtensor<double, 2> x = XDMFFile::read_geometry_data(name, xpath);
+  auto [cells, cshape] = XDMFFile::read_topology_data(name, xpath);
+  auto [x, xshape] = XDMFFile::read_geometry_data(name, xpath);
 
   // Create mesh
-  std::vector<std::int64_t> data(cells.data(), cells.data() + cells.size());
-  std::vector<std::int32_t> offset(cells.shape(0) + 1, 0);
-  for (std::size_t i = 0; i < cells.shape(0); ++i)
-    offset[i + 1] = offset[i] + cells.shape(1);
+  std::vector<std::int32_t> offset(cshape[0] + 1, 0);
+  for (std::size_t i = 0; i < cshape[0]; ++i)
+    offset[i + 1] = offset[i] + cshape[1];
 
-  graph::AdjacencyList<std::int64_t> cells_adj(std::move(data),
+  graph::AdjacencyList<std::int64_t> cells_adj(std::move(cells),
                                                std::move(offset));
 
   mesh::Mesh mesh
-      = mesh::create_mesh(_comm.comm(), cells_adj, element, x, mode);
+      = mesh::create_mesh(_comm.comm(), cells_adj, element, x, xshape, mode);
   mesh.name = name;
   return mesh;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<std::int64_t, 2>
+std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
 XDMFFile::read_topology_data(const std::string name,
                              const std::string xpath) const
 {
@@ -267,7 +265,7 @@ XDMFFile::read_topology_data(const std::string name,
   return xdmf_mesh::read_topology_data(_comm.comm(), _h5_id, grid_node);
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2>
+std::pair<std::vector<double>, std::array<std::size_t, 2>>
 XDMFFile::read_geometry_data(const std::string name,
                              const std::string xpath) const
 {
@@ -334,7 +332,7 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
   if (!grid_node)
     throw std::runtime_error("<Grid> with name '" + name + "' not found.");
 
-  const xt::xtensor<std::int64_t, 2> entities = read_topology_data(name, xpath);
+  const auto [entities, eshape] = read_topology_data(name, xpath);
 
   pugi::xml_node values_data_node
       = grid_node.child("Attribute").child("DataItem");
@@ -347,14 +345,11 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
 
   // Permute entities from VTK to DOLFINx ordering
   std::vector<std::int64_t> entities1 = io::cells::apply_permutation(
-      std::span(entities.data(), entities.size()),
-      {entities.shape(0), entities.shape(1)},
-      io::cells::perm_vtk(cell_type, entities.shape(1)));
+      entities, eshape, io::cells::perm_vtk(cell_type, eshape[1]));
 
   std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
       entities_values = xdmf_utils::distribute_entity_data(
-          *mesh, mesh::cell_dim(cell_type),
-          std::span(entities1.data(), entities1.size()), values);
+          *mesh, mesh::cell_dim(cell_type), entities1, values);
 
   LOG(INFO) << "XDMF create meshtags";
   const std::size_t num_vertices_per_entity = mesh::cell_num_entities(

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -236,7 +236,11 @@ mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
   const xt::xtensor<double, 2> x = XDMFFile::read_geometry_data(name, xpath);
 
   // Create mesh
-  auto [data, offset] = graph::create_adjacency_data(cells);
+  std::vector<std::int64_t> data(cells.data(), cells.data() + cells.size());
+  std::vector<std::int32_t> offset(cells.shape(0) + 1, 0);
+  for (std::size_t i = 0; i < cells.shape(0); ++i)
+    offset[i + 1] = offset[i] + cells.shape(1);
+
   graph::AdjacencyList<std::int64_t> cells_adj(std::move(data),
                                                std::move(offset));
 
@@ -342,13 +346,15 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
   mesh::CellType cell_type = mesh::to_type(cell_type_str.first);
 
   // Permute entities from VTK to DOLFINx ordering
-  xt::xtensor<std::int64_t, 2> entities1 = io::cells::compute_permutation(
-      entities, io::cells::perm_vtk(cell_type, entities.shape(1)));
+  std::vector<std::int64_t> entities1 = io::cells::apply_permutation(
+      std::span(entities.data(), entities.size()),
+      {entities.shape(0), entities.shape(1)},
+      io::cells::perm_vtk(cell_type, entities.shape(1)));
 
   std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
       entities_values = xdmf_utils::distribute_entity_data(
           *mesh, mesh::cell_dim(cell_type),
-          xtl::span(entities1.data(), entities1.size()), values);
+          std::span(entities1.data(), entities1.size()), values);
 
   LOG(INFO) << "XDMF create meshtags";
   const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
@@ -360,7 +366,7 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
                                       num_vertices_per_entity);
   mesh::MeshTags meshtags = mesh::create_meshtags(
       mesh, mesh::cell_dim(cell_type), entities_adj,
-      xtl::span<const std::int32_t>(entities_values.second));
+      std::span<const std::int32_t>(entities_values.second));
   meshtags.name = name;
 
   return meshtags;

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <xtensor/xtensor.hpp>
 
 namespace pugi
 {

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -12,7 +12,6 @@
 #include <filesystem>
 #include <memory>
 #include <string>
-#include <xtensor/xtensor.hpp>
 
 namespace pugi
 {
@@ -111,17 +110,17 @@ public:
   /// @param[in] name Name of the mesh (Grid)
   /// @param[in] xpath XPath where Mesh Grid data is located
   /// @return (Cell type, degree), and cells topology (global node indexing)
-  xt::xtensor<std::int64_t, 2> read_topology_data(const std::string name,
-                                                  const std::string xpath
-                                                  = "/Xdmf/Domain") const;
+  std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
+  read_topology_data(const std::string name,
+                     const std::string xpath = "/Xdmf/Domain") const;
 
   /// Read Geometry data for Mesh
   /// @param[in] name Name of the mesh (Grid)
   /// @param[in] xpath XPath where Mesh Grid data is located
   /// @return points on each process
-  xt::xtensor<double, 2> read_geometry_data(const std::string name,
-                                            const std::string xpath
-                                            = "/Xdmf/Domain") const;
+  std::pair<std::vector<double>, std::array<std::size_t, 2>>
+  read_geometry_data(const std::string name,
+                     const std::string xpath = "/Xdmf/Domain") const;
 
   /// Read information about cell type
   /// @param[in] grid_name Name of Grid for which cell type is needed

--- a/cpp/dolfinx/io/cells.cpp
+++ b/cpp/dolfinx/io/cells.cpp
@@ -10,7 +10,6 @@
 #include <dolfinx/mesh/cell_types.h>
 #include <numeric>
 #include <stdexcept>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 namespace
@@ -364,17 +363,21 @@ io::cells::transpose(const std::vector<std::uint8_t>& map)
   return transpose;
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<std::int64_t, 2>
-io::cells::compute_permutation(const xt::xtensor<std::int64_t, 2>& cells,
-                               const std::vector<std::uint8_t>& p)
+std::vector<std::int64_t>
+io::cells::apply_permutation(const std::span<const std::int64_t>& cells,
+                             std::array<std::size_t, 2> shape,
+                             const std::span<const std::uint8_t>& p)
 {
+  assert(cells.size() == shape[0] * shape[1]);
+  assert(shape[1] == p.size());
+
   LOG(INFO) << "IO permuting cells";
-  xt::xtensor<std::int64_t, 2> cells_new(cells.shape());
-  for (std::size_t c = 0; c < cells_new.shape(0); ++c)
+  std::vector<std::int64_t> cells_new(cells.size());
+  for (std::size_t c = 0; c < shape[0]; ++c)
   {
-    auto cell = xt::row(cells, c);
-    auto cell_new = xt::row(cells_new, c);
-    for (std::size_t i = 0; i < cell_new.shape(0); ++i)
+    auto cell = cells.subspan(c * shape[1], shape[1]);
+    std::span cell_new(cells_new.data() + c * shape[1], shape[1]);
+    for (std::size_t i = 0; i < shape[1]; ++i)
       cell_new[i] = cell[p[i]];
   }
   return cells_new;

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -6,10 +6,11 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <dolfinx/mesh/cell_types.h>
+#include <span>
 #include <vector>
-#include <xtensor/xtensor.hpp>
 
 /// Functions for the re-ordering of input mesh topology to the DOLFINx
 /// ordering, and transpose orderings for file output.
@@ -106,14 +107,17 @@ std::vector<std::uint8_t> transpose(const std::vector<std::uint8_t>& map);
 
 /// Permute cell topology by applying a permutation array for each cell
 /// @param[in] cells Array of cell topologies, with each row
-/// representing a cell
+/// representing a cell (row-major storage)
+/// @param[in] shape The shape of the `cells` array
 /// @param[in] p The permutation array that maps `a_p[i] = a[p[i]]`,
 /// where `a_p` is the permuted array
 /// @return Permuted cell topology, where for a cell `v_new[i] =
-/// v_old[map[i]]`
-xt::xtensor<std::int64_t, 2>
-compute_permutation(const xt::xtensor<std::int64_t, 2>& cells,
-                    const std::vector<std::uint8_t>& p);
+/// v_old[map[i]]`. The storage is row-major and the shape is the same
+/// as `cells`.
+std::vector<std::int64_t>
+apply_permutation(const std::span<const std::int64_t>& cells,
+                  std::array<std::size_t, 2> shape,
+                  const std::span<const std::uint8_t>& p);
 
 /// Get VTK cell identifier
 /// @param[in] cell The cell type

--- a/cpp/dolfinx/io/vtk_utils.cpp
+++ b/cpp/dolfinx/io/vtk_utils.cpp
@@ -15,8 +15,6 @@
 #include <dolfinx/mesh/Topology.h>
 #include <span>
 #include <tuple>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 

--- a/cpp/dolfinx/io/vtk_utils.cpp
+++ b/cpp/dolfinx/io/vtk_utils.cpp
@@ -13,10 +13,10 @@
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
+#include <span>
 #include <tuple>
-#include <xtensor/xbuilder.hpp>
+#include <xtensor/xadapt.hpp>
 #include <xtensor/xview.hpp>
-#include <xtl/xspan.hpp>
 
 using namespace dolfinx;
 
@@ -24,16 +24,17 @@ namespace
 {
 /// Tabulate the coordinate for every 'node' in a Lagrange function
 /// space.
+/// @pre `V` must be (discontinuous) Lagrange and must not be a subspace
 /// @param[in] V The function space
 /// @return Mesh coordinate data
 /// -# Node coordinates (shape={num_dofs, 3}) where the ith row
 /// corresponds to the coordinate of the ith dof in `V` (local to
 /// process)
+/// -# Node coordinates shape
 /// -# Unique global index for each node
 /// -# ghost index for each node (0=non-ghost, 1=ghost)
-/// @pre `V` must be (discontinuous) Lagrange and must not be a subspace
-std::tuple<xt::xtensor<double, 2>, std::vector<std::int64_t>,
-           std::vector<std::uint8_t>>
+std::tuple<std::vector<double>, std::array<std::size_t, 2>,
+           std::vector<std::int64_t>, std::vector<std::uint8_t>>
 tabulate_lagrange_dof_coordinates(const fem::FunctionSpace& V)
 {
   auto mesh = V.mesh();
@@ -54,56 +55,67 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace& V)
   assert(element);
   const int e_bs = element->block_size();
   const std::size_t scalar_dofs = element->space_dimension() / e_bs;
-  const std::int32_t num_nodes
+  const std::size_t num_nodes
       = index_map_bs * (map_dofs->size_local() + map_dofs->num_ghosts())
         / dofmap_bs;
 
   // Get the dof coordinates on the reference element and the  mesh
   // coordinate map
-  const xt::xtensor<double, 2>& X = element->interpolation_points();
+  const auto [X, Xshape] = element->interpolation_points();
   const fem::CoordinateElement& cmap = mesh->geometry().cmap();
 
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& dofmap_x
       = mesh->geometry().dofmap();
-  xtl::span<const double> x_g = mesh->geometry().x();
+  std::span<const double> x_g = mesh->geometry().x();
   const std::size_t num_dofs_g = cmap.dim();
 
-  xtl::span<const std::uint32_t> cell_info;
+  std::span<const std::uint32_t> cell_info;
   if (element->needs_dof_transformations())
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = std::span(mesh->topology().get_cell_permutation_info());
   }
   const auto apply_dof_transformation
       = element->get_dof_transformation_function<double>();
 
+  namespace stdex = std::experimental;
+  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan4_t = stdex::mdspan<double, stdex::dextents<std::size_t, 4>>;
+
   // Tabulate basis functions at node reference coordinates
-  const xt::xtensor<double, 2> phi
-      = xt::view(cmap.tabulate(0, X), 0, xt::all(), xt::all(), 0);
+  const std::array<std::size_t, 4> phi_shape
+      = cmap.tabulate_shape(0, Xshape[0]);
+  std::vector<double> phi_b(
+      std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+  cmdspan4_t phi_full(phi_b.data(), phi_shape);
+  cmap.tabulate(0, X, Xshape, phi_b);
+  auto phi = stdex::submdspan(phi_full, 0, stdex::full_extent,
+                              stdex::full_extent, 0);
 
   // Loop over cells and tabulate dofs
   auto map = mesh->topology().index_map(tdim);
   assert(map);
   const std::int32_t num_cells = map->size_local() + map->num_ghosts();
-  xt::xtensor<double, 2> x = xt::zeros<double>({scalar_dofs, gdim});
-  xt::xtensor<double, 2> coordinate_dofs({num_dofs_g, gdim});
-  xt::xtensor<double, 2> coords = xt::zeros<double>({num_nodes, 3});
+  std::vector<double> x_b(scalar_dofs * gdim);
+  mdspan2_t x(x_b.data(), scalar_dofs, gdim);
+  std::vector<double> coordinate_dofs_b(num_dofs_g * gdim);
+  mdspan2_t coordinate_dofs(coordinate_dofs_b.data(), num_dofs_g, gdim);
+
+  std::vector<double> coords(num_nodes * 3, 0.0);
+  std::array<std::size_t, 2> cshape = {num_nodes, 3};
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
     // Extract cell geometry
     auto dofs_x = dofmap_x.links(c);
     for (std::size_t i = 0; i < dofs_x.size(); ++i)
-    {
-      std::copy_n(std::next(x_g.begin(), 3 * dofs_x[i]), gdim,
-                  std::next(coordinate_dofs.begin(), i * gdim));
-    }
+      for (std::size_t j = 0; j < gdim; ++j)
+        coordinate_dofs(i, j) = x_g[3 * dofs_x[i] + j];
 
     // Tabulate dof coordinates on cell
     cmap.push_forward(x, coordinate_dofs, phi);
-    apply_dof_transformation(xtl::span(x.data(), x.size()),
-                             xtl::span(cell_info.data(), cell_info.size()), c,
-                             x.shape(1));
+    apply_dof_transformation(x_b, std::span(cell_info.data(), cell_info.size()),
+                             c, x.extent(1));
 
     // Copy dof coordinates into vector
     auto dofs = dofmap->cell_dofs(c);
@@ -111,7 +123,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace& V)
     {
       std::int32_t dof = dofs[i];
       for (std::size_t j = 0; j < gdim; ++j)
-        coords(dof, j) = x(i, j);
+        coords[3 * dof + j] = x(i, j);
     }
   }
 
@@ -127,13 +139,14 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace& V)
   std::vector<std::uint8_t> id_ghost(num_nodes, 0);
   std::fill(std::next(id_ghost.begin(), size_local), id_ghost.end(), 1);
 
-  return {std::move(coords), std::move(x_id), std::move(id_ghost)};
+  return {std::move(coords), cshape, std::move(x_id), std::move(id_ghost)};
 }
 } // namespace
 
 //-----------------------------------------------------------------------------
-std::tuple<xt::xtensor<double, 2>, std::vector<std::int64_t>,
-           std::vector<std::uint8_t>, xt::xtensor<std::int32_t, 2>>
+std::tuple<std::vector<double>, std::array<std::size_t, 2>,
+           std::vector<std::int64_t>, std::vector<std::uint8_t>,
+           std::vector<std::int64_t>, std::array<std::size_t, 2>>
 io::vtk_mesh_from_space(const fem::FunctionSpace& V)
 {
   auto mesh = V.mesh();
@@ -144,7 +157,7 @@ io::vtk_mesh_from_space(const fem::FunctionSpace& V)
   if (V.element()->is_mixed())
     throw std::runtime_error("Can create VTK mesh from a mixed element");
 
-  const auto [x, x_id, x_ghost] = tabulate_lagrange_dof_coordinates(V);
+  const auto [x, xshape, x_id, x_ghost] = tabulate_lagrange_dof_coordinates(V);
   auto map = mesh->topology().index_map(tdim);
   const std::size_t num_cells = map->size_local() + map->num_ghosts();
 
@@ -159,19 +172,24 @@ io::vtk_mesh_from_space(const fem::FunctionSpace& V)
 
   // Extract topology for all local cells as
   // [v0_0, ...., v0_N0, v1_0, ...., v1_N1, ....]
-  xt::xtensor<std::int32_t, 2> vtk_topology({num_cells, num_nodes});
-  for (std::size_t c = 0; c < num_cells; ++c)
+  std::array<std::size_t, 2> shape = {num_cells, num_nodes};
+  std::vector<std::int64_t> vtk_topology(shape[0] * shape[1]);
+  for (std::size_t c = 0; c < shape[0]; ++c)
   {
     auto dofs = dofmap->cell_dofs(c);
     for (std::size_t i = 0; i < dofs.size(); ++i)
-      vtk_topology(c, i) = dofs[vtkmap[i]];
+      vtk_topology[c * shape[1] + i] = dofs[vtkmap[i]];
   }
 
-  return {std::move(x), std::move(x_id), std::move(x_ghost),
-          std::move(vtk_topology)};
+  return {std::move(x),
+          xshape,
+          std::move(x_id),
+          std::move(x_ghost),
+          std::move(vtk_topology),
+          shape};
 }
 //-----------------------------------------------------------------------------
-xt::xtensor<std::int64_t, 2>
+std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
 io::extract_vtk_connectivity(const mesh::Mesh& mesh)
 {
   // Get DOLFINx to VTK permutation
@@ -190,15 +208,16 @@ io::extract_vtk_connectivity(const mesh::Mesh& mesh)
   // Build mesh connectivity
 
   // Loop over cells
-  xt::xtensor<std::int64_t, 2> topology({num_cells, num_nodes});
+  std::array<std::size_t, 2> shape = {num_cells, num_nodes};
+  std::vector<std::int64_t> topology(shape[0] * shape[1]);
   for (std::size_t c = 0; c < num_cells; ++c)
   {
     // For each cell, get the 'nodes' and place in VTK order
     auto dofs_x = dofmap_x.links(c);
     for (std::size_t i = 0; i < dofs_x.size(); ++i)
-      topology(c, i) = dofs_x[vtkmap[i]];
+      topology[c * shape[1] + i] = dofs_x[vtkmap[i]];
   }
 
-  return topology;
+  return {std::move(topology), shape};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -6,11 +6,10 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
-#include <dolfinx/mesh/cell_types.h>
 #include <tuple>
 #include <vector>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx
 {
@@ -21,24 +20,28 @@ class FunctionSpace;
 
 namespace mesh
 {
-enum class CellType;
 class Mesh;
 } // namespace mesh
 
 namespace io
 {
-/// Given a FunctionSpace, create a topology and geometry based on the
-/// dof coordinates
+/// @brief Given a FunctionSpace, create a topology and geometry based
+/// on the dof coordinates.
+///
 /// @pre `V` must be a (discontinuous) Lagrange space
+///
 /// @param[in] V The function space
 /// @returns Mesh data
-/// -# node coordinates (shape={num_nodes, 3})
+/// -# node coordinates (shape={num_nodes, 3}), row-major storage
+/// -# node coordinates shape
 /// -# unique global ID for each node (a node that appears on more than
 /// one rank will have the same global ID)
 /// -# ghost index for each node (0=non-ghost, 1=ghost)
-/// -# cells (shape={num_cells, nodes_per_cell)})
-std::tuple<xt::xtensor<double, 2>, std::vector<std::int64_t>,
-           std::vector<std::uint8_t>, xt::xtensor<std::int32_t, 2>>
+/// -# cells (shape={num_cells, nodes_per_cell)}), row-major storage
+/// -# cell shape (shape={num_cells, nodes_per_cell)})
+std::tuple<std::vector<double>, std::array<std::size_t, 2>,
+           std::vector<std::int64_t>, std::vector<std::uint8_t>,
+           std::vector<std::int64_t>, std::array<std::size_t, 2>>
 vtk_mesh_from_space(const fem::FunctionSpace& V);
 
 /// Extract the cell topology (connectivity) in VTK ordering for all
@@ -52,7 +55,8 @@ vtk_mesh_from_space(const fem::FunctionSpace& V);
 /// indices in the mesh geometry array
 /// @note Even if the indices are local (int32), both Fides and VTX
 /// require int64 as local input
-xt::xtensor<std::int64_t, 2> extract_vtk_connectivity(const mesh::Mesh& mesh);
+std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
+extract_vtk_connectivity(const mesh::Mesh& mesh);
 
 } // namespace io
 } // namespace dolfinx

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -11,6 +11,7 @@
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/fem/ElementDofLayout.h>
 #include <pugixml.hpp>
+#include <xtensor/xadapt.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::io;
@@ -21,7 +22,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
                                   const std::string path_prefix,
                                   const mesh::Topology& topology,
                                   const mesh::Geometry& geometry, int dim,
-                                  const xtl::span<const std::int32_t>& entities)
+                                  const std::span<const std::int32_t>& entities)
 {
   LOG(INFO) << "Adding topology data to node \"" << xml_node.path('/') << "\"";
 
@@ -170,7 +171,7 @@ void xdmf_mesh::add_geometry_data(MPI_Comm comm, pugi::xml_node& xml_node,
   // Increase 1D to 2D because XDMF has no "X" geometry, use "XY"
   const int width = (gdim == 1) ? 2 : gdim;
 
-  xtl::span<const double> _x = geometry.x();
+  std::span<const double> _x = geometry.x();
 
   int num_values = num_points_local * width;
   std::vector<double> x(num_values, 0.0);
@@ -224,7 +225,7 @@ void xdmf_mesh::add_mesh(MPI_Comm comm, pugi::xml_node& xml_node,
 
   add_topology_data(comm, grid_node, h5_id, path_prefix, mesh.topology(),
                     mesh.geometry(), tdim,
-                    xtl::span<std::int32_t>(cells.data(), num_cells));
+                    std::span<std::int32_t>(cells.data(), num_cells));
 
   // Add geometry node and attributes (including writing data)
   add_geometry_data(comm, grid_node, h5_id, path_prefix, mesh.geometry());
@@ -304,18 +305,11 @@ xdmf_mesh::read_topology_data(MPI_Comm comm, const hid_t h5_id,
       = xdmf_read::get_dataset<std::int64_t>(comm, topology_data_node, h5_id);
   const std::size_t num_local_cells = topology_data.size() / npoint_per_cell;
 
-  std::array<std::size_t, 2> shape = {num_local_cells, npoint_per_cell};
-
-  // The below should work, but misbehaves with the Intel icpx compiler
-  // auto cells_vtk = xt::adapt(topology_data.data(), topology_data.size(),
-  //                            xt::no_ownership(), shape);
-
-  // Explicitly copy to an xtensor
-  xt::xtensor<std::int64_t, 2> cells_vtk = xt::empty<std::int64_t>(shape);
-  std::copy(topology_data.begin(), topology_data.end(), cells_vtk.begin());
-
   //  Permute cells from VTK to DOLFINx ordering
-  return io::cells::compute_permutation(
-      cells_vtk, io::cells::perm_vtk(cell_type, cells_vtk.shape(1)));
+  std::array<std::size_t, 2> shape = {num_local_cells, npoint_per_cell};
+  std::vector<std::int64_t> cells = io::cells::apply_permutation(
+      topology_data, shape, io::cells::perm_vtk(cell_type, shape[1]));
+
+  return xt::adapt(cells, std::vector<std::size_t>{shape[0], shape[1]});
 }
 //----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/xdmf_mesh.h
+++ b/cpp/dolfinx/io/xdmf_mesh.h
@@ -8,9 +8,9 @@
 
 #include <hdf5.h>
 #include <mpi.h>
+#include <span>
 #include <string>
 #include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
 
 namespace pugi
 {
@@ -52,7 +52,7 @@ void add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
                        const hid_t h5_id, const std::string path_prefix,
                        const mesh::Topology& topology,
                        const mesh::Geometry& geometry, int cell_dim,
-                       const xtl::span<const std::int32_t>& entities);
+                       const std::span<const std::int32_t>& entities);
 
 /// Add Geometry xml node
 void add_geometry_data(MPI_Comm comm, pugi::xml_node& xml_node,

--- a/cpp/dolfinx/io/xdmf_mesh.h
+++ b/cpp/dolfinx/io/xdmf_mesh.h
@@ -6,11 +6,13 @@
 
 #pragma once
 
+#include <array>
 #include <hdf5.h>
 #include <mpi.h>
 #include <span>
 #include <string>
-#include <xtensor/xtensor.hpp>
+#include <utility>
+#include <vector>
 
 namespace pugi
 {
@@ -59,16 +61,25 @@ void add_geometry_data(MPI_Comm comm, pugi::xml_node& xml_node,
                        const hid_t h5_id, const std::string path_prefix,
                        const mesh::Geometry& geometry);
 
-/// Read Geometry data
-/// @returns geometry
-xt::xtensor<double, 2> read_geometry_data(MPI_Comm comm, const hid_t h5_id,
-                                          const pugi::xml_node& node);
+/// @brief Read geometry (coordinate) data.
+///
+/// @returns The coordinates of each 'node'. The returned data is (0) an
+/// array holding the coordinates (row-major storage) and (1) the shape
+/// of the coordinate array. The shape is `(num_nodes, geometric
+/// dimension)`.
+std::pair<std::vector<double>, std::array<std::size_t, 2>>
+read_geometry_data(MPI_Comm comm, const hid_t h5_id,
+                   const pugi::xml_node& node);
 
-/// Read Topology data
-/// @returns ((cell type, degree), topology)
-xt::xtensor<std::int64_t, 2> read_topology_data(MPI_Comm comm,
-                                                const hid_t h5_id,
-                                                const pugi::xml_node& node);
+/// @brief Read topology (cell connectivity) data.
+///
+/// @returns Mesh topology in DOLFINx ordering, where data row `i` lists
+/// the 'nodes' of cell `i`. The returned data is (0) an array holding
+/// the topology data (row-major storage) and (1) the shape of the
+/// topology array. The shape is `(num_cells, num_nodes_per_cell)`
+std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
+read_topology_data(MPI_Comm comm, const hid_t h5_id,
+                   const pugi::xml_node& node);
 
 } // namespace io::xdmf_mesh
 } // namespace dolfinx

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -14,9 +14,9 @@
 #include <dolfinx/mesh/MeshTags.h>
 #include <hdf5.h>
 #include <pugixml.hpp>
+#include <span>
 #include <string>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx
 {
@@ -54,7 +54,7 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
   xdmf_mesh::add_topology_data(
       comm, xml_node, h5_id, path_prefix, mesh->topology(), mesh->geometry(),
       dim,
-      xtl::span<const std::int32_t>(meshtags.indices().data(),
+      std::span<const std::int32_t>(meshtags.indices().data(),
                                     num_active_entities));
 
   // Add attribute node with values
@@ -74,7 +74,7 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
   const bool use_mpi_io = (dolfinx::MPI::size(comm) > 1);
   xdmf_utils::add_data_item(
       attribute_node, h5_id, path_prefix + std::string("/Values"),
-      xtl::span<const T>(meshtags.values().data(), num_active_entities), offset,
+      std::span<const T>(meshtags.values().data(), num_active_entities), offset,
       {global_num_values, 1}, "", use_mpi_io);
 }
 

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -13,10 +13,10 @@
 #include <filesystem>
 #include <numeric>
 #include <pugixml.hpp>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace pugi
 {
@@ -103,8 +103,8 @@ std::string vtk_cell_type_str(mesh::CellType cell_type, int num_nodes);
 /// for this triangle.
 std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
 distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
-                       const xtl::span<const std::int64_t>& entities,
-                       const xtl::span<const std::int32_t>& data);
+                       const std::span<const std::int64_t>& entities,
+                       const std::span<const std::int32_t>& data);
 
 /// TODO: Document
 template <typename T>

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -12,9 +12,9 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <mpi.h>
 #include <numeric>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::la
 {
@@ -139,9 +139,9 @@ public:
   /// @todo clarify setting on non-owned enrties
   auto mat_set_values()
   {
-    return [&](const xtl::span<const std::int32_t>& rows,
-               const xtl::span<const std::int32_t>& cols,
-               const xtl::span<const T>& data) -> int
+    return [&](const std::span<const std::int32_t>& rows,
+               const std::span<const std::int32_t>& cols,
+               const std::span<const T>& data) -> int
     {
       this->set(data, rows, cols);
       return 0;
@@ -154,9 +154,9 @@ public:
   /// @return Function for inserting values into `A`
   auto mat_add_values()
   {
-    return [&](const xtl::span<const std::int32_t>& rows,
-               const xtl::span<const std::int32_t>& cols,
-               const xtl::span<const T>& data) -> int
+    return [&](const std::span<const std::int32_t>& rows,
+               const std::span<const std::int32_t>& cols,
+               const std::span<const T>& data) -> int
     {
       this->add(data, rows, cols);
       return 0;
@@ -181,7 +181,7 @@ public:
       throw std::runtime_error("Block size not yet supported");
 
     // Compute off-diagonal offset for each row
-    xtl::span<const std::int32_t> num_diag_nnz = p.off_diagonal_offset();
+    std::span<const std::int32_t> num_diag_nnz = p.off_diagonal_offset();
     _off_diagonal_offset.reserve(num_diag_nnz.size());
     std::transform(num_diag_nnz.begin(), num_diag_nnz.end(), _row_ptr.begin(),
                    std::back_inserter(_off_diagonal_offset), std::plus{});
@@ -352,9 +352,9 @@ public:
   /// set in the matrix
   /// @param[in] rows The row indices of `x`
   /// @param[in] cols The column indices of `x`
-  void set(const xtl::span<const T>& x,
-           const xtl::span<const std::int32_t>& rows,
-           const xtl::span<const std::int32_t>& cols)
+  void set(const std::span<const T>& x,
+           const std::span<const std::int32_t>& rows,
+           const std::span<const std::int32_t>& cols)
   {
     impl::set_csr(_data, _cols, _row_ptr, x, rows, cols,
                   _index_maps[0]->size_local());
@@ -372,9 +372,9 @@ public:
   /// add to the matrix
   /// @param[in] rows The row indices of `x`
   /// @param[in] cols The column indices of `x`
-  void add(const xtl::span<const T>& x,
-           const xtl::span<const std::int32_t>& rows,
-           const xtl::span<const std::int32_t>& cols)
+  void add(const std::span<const T>& x,
+           const std::span<const std::int32_t>& rows,
+           const std::span<const std::int32_t>& cols)
   {
     impl::add_csr(_data, _cols, _row_ptr, x, rows, cols);
   }

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -141,8 +141,8 @@ SparsityPattern::SparsityPattern(
   }
 }
 //-----------------------------------------------------------------------------
-void SparsityPattern::insert(const xtl::span<const std::int32_t>& rows,
-                             const xtl::span<const std::int32_t>& cols)
+void SparsityPattern::insert(const std::span<const std::int32_t>& rows,
+                             const std::span<const std::int32_t>& cols)
 {
   if (_graph)
   {
@@ -166,7 +166,7 @@ void SparsityPattern::insert(const xtl::span<const std::int32_t>& rows,
   }
 }
 //-----------------------------------------------------------------------------
-void SparsityPattern::insert_diagonal(const xtl::span<const std::int32_t>& rows)
+void SparsityPattern::insert_diagonal(const std::span<const std::int32_t>& rows)
 {
   if (_graph)
   {
@@ -419,7 +419,7 @@ const graph::AdjacencyList<std::int32_t>& SparsityPattern::graph() const
   return *_graph;
 }
 //-----------------------------------------------------------------------------
-xtl::span<const int> SparsityPattern::off_diagonal_offset() const
+std::span<const int> SparsityPattern::off_diagonal_offset() const
 {
   return _off_diagonal_offset;
 }

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -8,9 +8,9 @@
 
 #include <dolfinx/common/MPI.h>
 #include <memory>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::graph
 {
@@ -75,13 +75,13 @@ public:
   SparsityPattern& operator=(SparsityPattern&& pattern) = default;
 
   /// Insert non-zero locations using local (process-wise) indices
-  void insert(const xtl::span<const std::int32_t>& rows,
-              const xtl::span<const std::int32_t>& cols);
+  void insert(const std::span<const std::int32_t>& rows,
+              const std::span<const std::int32_t>& cols);
 
   /// Insert non-zero locations on the diagonal
   /// @param[in] rows The rows in local (process-wise) indices. The
   /// indices must exist in the row IndexMap.
-  void insert_diagonal(const xtl::span<const std::int32_t>& rows);
+  void insert_diagonal(const std::span<const std::int32_t>& rows);
 
   /// Finalize sparsity pattern and communicate off-process entries
   void assemble();
@@ -133,7 +133,7 @@ public:
 
   /// Row-wise start of off-diagonal (unowned columns) on each row
   /// @note Includes ghost rows
-  xtl::span<const int> off_diagonal_offset() const;
+  std::span<const int> off_diagonal_offset() const;
 
   /// Return MPI communicator
   MPI_Comm comm() const;

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -13,8 +13,8 @@
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <span>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::la
 {
@@ -74,7 +74,7 @@ public:
   void scatter_fwd_begin()
   {
     const std::int32_t local_size = _bs * _map->size_local();
-    xtl::span<const T> x_local(_x.data(), local_size);
+    std::span<const T> x_local(_x.data(), local_size);
 
     auto pack = [](const auto& in, const auto& idx, auto& out)
     {
@@ -83,8 +83,8 @@ public:
     };
     pack(x_local, _scatterer->local_indices(), _buffer_local);
 
-    _scatterer->scatter_fwd_begin(xtl::span<const T>(_buffer_local),
-                                  xtl::span<T>(_buffer_remote), _request);
+    _scatterer->scatter_fwd_begin(std::span<const T>(_buffer_local),
+                                  std::span<T>(_buffer_remote), _request);
   }
 
   /// End scatter of local data from owner to ghosts on other ranks
@@ -93,7 +93,7 @@ public:
   {
     const std::int32_t local_size = _bs * _map->size_local();
     const std::int32_t num_ghosts = _bs * _map->num_ghosts();
-    xtl::span<T> x_remote(_x.data() + local_size, num_ghosts);
+    std::span<T> x_remote(_x.data() + local_size, num_ghosts);
     _scatterer->scatter_fwd_end(_request);
 
     auto unpack = [](const auto& in, const auto& idx, auto& out, auto op)
@@ -120,7 +120,7 @@ public:
   {
     const std::int32_t local_size = _bs * _map->size_local();
     const std::int32_t num_ghosts = _bs * _map->num_ghosts();
-    xtl::span<T> x_remote(_x.data() + local_size, num_ghosts);
+    std::span<T> x_remote(_x.data() + local_size, num_ghosts);
 
     auto pack = [](const auto& in, const auto& idx, auto& out)
     {
@@ -129,8 +129,8 @@ public:
     };
     pack(x_remote, _scatterer->remote_indices(), _buffer_remote);
 
-    _scatterer->scatter_rev_begin(xtl::span<const T>(_buffer_remote),
-                                  xtl::span<T>(_buffer_local), _request);
+    _scatterer->scatter_rev_begin(std::span<const T>(_buffer_remote),
+                                  std::span<T>(_buffer_local), _request);
   }
 
   /// End scatter of ghost data to owner. This process may receive data
@@ -143,7 +143,7 @@ public:
   void scatter_rev_end(BinaryOperation op)
   {
     const std::int32_t local_size = _bs * _map->size_local();
-    xtl::span<T> x_local(_x.data(), local_size);
+    std::span<T> x_local(_x.data(), local_size);
     _scatterer->scatter_rev_end(_request);
 
     auto unpack = [](const auto& in, const auto& idx, auto& out, auto op)
@@ -173,10 +173,10 @@ public:
   constexpr int bs() const { return _bs; }
 
   /// Get local part of the vector (const version)
-  xtl::span<const T> array() const { return xtl::span<const T>(_x); }
+  std::span<const T> array() const { return std::span<const T>(_x); }
 
   /// Get local part of the vector
-  xtl::span<T> mutable_array() { return xtl::span(_x); }
+  std::span<T> mutable_array() { return std::span(_x); }
 
   /// Get the allocator associated with the container
   constexpr allocator_type allocator() const { return _x.get_allocator(); }
@@ -213,8 +213,8 @@ T inner_product(const Vector<T, Allocator>& a, const Vector<T, Allocator>& b)
   const std::int32_t local_size = a.bs() * a.map()->size_local();
   if (local_size != b.bs() * b.map()->size_local())
     throw std::runtime_error("Incompatible vector sizes");
-  xtl::span<const T> x_a = a.array().subspan(0, local_size);
-  xtl::span<const T> x_b = b.array().subspan(0, local_size);
+  std::span<const T> x_a = a.array().subspan(0, local_size);
+  std::span<const T> x_b = b.array().subspan(0, local_size);
 
   const T local = std::transform_reduce(
       x_a.begin(), x_a.end(), x_b.begin(), static_cast<T>(0), std::plus{},
@@ -258,7 +258,7 @@ auto norm(const Vector<T, Allocator>& a, Norm type = Norm::l2)
   case Norm::linf:
   {
     const std::int32_t size_local = a.bs() * a.map()->size_local();
-    xtl::span<const T> x_a = a.array().subspan(0, size_local);
+    std::span<const T> x_a = a.array().subspan(0, size_local);
     auto max_pos = std::max_element(x_a.begin(), x_a.end(),
                                     [](T a, T b)
                                     { return std::norm(a) < std::norm(b); });
@@ -279,7 +279,7 @@ auto norm(const Vector<T, Allocator>& a, Norm type = Norm::l2)
 /// modified in-place.
 /// @param[in] tol The tolerance used to detect a linear dependency
 template <typename T, typename U>
-void orthonormalize(const xtl::span<Vector<T, U>>& basis, double tol = 1.0e-10)
+void orthonormalize(const std::span<Vector<T, U>>& basis, double tol = 1.0e-10)
 {
   // Loop over each vector in basis
   for (std::size_t i = 0; i < basis.size(); ++i)
@@ -313,7 +313,7 @@ void orthonormalize(const xtl::span<Vector<T, U>>& basis, double tol = 1.0e-10)
 /// @param[in] tol The tolerance used to test for orthonormality
 /// @return True is basis is orthonormal, otherwise false
 template <typename T, typename U>
-bool is_orthonormal(const xtl::span<const Vector<T, U>>& basis,
+bool is_orthonormal(const std::span<const Vector<T, U>>& basis,
                     double tol = 1.0e-10)
 {
   for (std::size_t i = 0; i < basis.size(); i++)

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -47,7 +47,7 @@ void la::petsc::error(int error_code, std::string filename,
 //-----------------------------------------------------------------------------
 std::vector<Vec>
 la::petsc::create_vectors(MPI_Comm comm,
-                          const std::vector<xtl::span<const PetscScalar>>& x)
+                          const std::vector<std::span<const PetscScalar>>& x)
 {
   std::vector<Vec> v(x.size());
   for (std::size_t i = 0; i < v.size(); ++i)
@@ -69,7 +69,7 @@ Vec la::petsc::create_vector(const dolfinx::common::IndexMap& map, int bs)
 }
 //-----------------------------------------------------------------------------
 Vec la::petsc::create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
-                             const xtl::span<const std::int64_t>& ghosts,
+                             const std::span<const std::int64_t>& ghosts,
                              int bs)
 {
   PetscErrorCode ierr;
@@ -89,7 +89,7 @@ Vec la::petsc::create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
 }
 //-----------------------------------------------------------------------------
 Vec la::petsc::create_vector_wrap(const common::IndexMap& map, int bs,
-                                  const xtl::span<const PetscScalar>& x)
+                                  const std::span<const PetscScalar>& x)
 {
   const std::int32_t size_local = bs * map.size_local();
   const std::int64_t size_global = bs * map.size_global();
@@ -137,7 +137,7 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
   VecGetSize(x_local, &n);
   const PetscScalar* array = nullptr;
   VecGetArrayRead(x_local, &array);
-  xtl::span _x(array, n);
+  std::span _x(array, n);
 
   // Copy PETSc Vec data in to local vectors
   std::vector<std::vector<PetscScalar>> x_b;
@@ -164,7 +164,7 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
 }
 //-----------------------------------------------------------------------------
 void la::petsc::scatter_local_vectors(
-    Vec x, const std::vector<xtl::span<const PetscScalar>>& x_b,
+    Vec x, const std::vector<std::span<const PetscScalar>>& x_b,
     const std::vector<
         std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps)
 {
@@ -182,7 +182,7 @@ void la::petsc::scatter_local_vectors(
   VecGetSize(x_local, &n);
   PetscScalar* array = nullptr;
   VecGetArray(x_local, &array);
-  xtl::span _x(array, n);
+  std::span _x(array, n);
 
   // Copy local vectors into PETSc Vec
   int offset = 0;
@@ -335,7 +335,7 @@ Mat la::petsc::create_matrix(MPI_Comm comm,
 }
 //-----------------------------------------------------------------------------
 MatNullSpace la::petsc::create_nullspace(MPI_Comm comm,
-                                         const xtl::span<const Vec>& basis)
+                                         const std::span<const Vec>& basis)
 {
   MatNullSpace ns = nullptr;
   PetscErrorCode ierr

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -15,9 +15,9 @@
 #include <petscmat.h>
 #include <petscoptions.h>
 #include <petscvec.h>
+#include <span>
 #include <string>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::common
 {
@@ -42,7 +42,7 @@ void error(int error_code, std::string filename, std::string petsc_function);
 /// @return Array of PETSc vectors
 std::vector<Vec>
 create_vectors(MPI_Comm comm,
-               const std::vector<xtl::span<const PetscScalar>>& x);
+               const std::vector<std::span<const PetscScalar>>& x);
 
 /// Create a ghosted PETSc Vec
 /// @note Caller is responsible for destroying the returned object
@@ -60,7 +60,7 @@ Vec create_vector(const common::IndexMap& map, int bs);
 /// `bs * (range[1] - range[0])`.
 /// @returns A PETSc Vec
 Vec create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
-                  const xtl::span<const std::int64_t>& ghosts, int bs);
+                  const std::span<const std::int64_t>& ghosts, int bs);
 
 /// Create a PETSc Vec that wraps the data in an array
 /// @param[in] map The index map that describes the parallel layout of
@@ -72,7 +72,7 @@ Vec create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
 /// @note The caller should call VecDestroy to free the return PETSc
 /// vector
 Vec create_vector_wrap(const common::IndexMap& map, int bs,
-                       const xtl::span<const PetscScalar>& x);
+                       const std::span<const PetscScalar>& x);
 
 /// Create a PETSc Vec that wraps the data in an array
 /// @param[in] x The vector to be wrapped
@@ -107,7 +107,7 @@ std::vector<std::vector<PetscScalar>> get_local_vectors(
 
 /// Scatter local vectors to Vec
 void scatter_local_vectors(
-    Vec x, const std::vector<xtl::span<const PetscScalar>>& x_b,
+    Vec x, const std::vector<std::span<const PetscScalar>>& x_b,
     const std::vector<
         std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
@@ -121,7 +121,7 @@ Mat create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 /// @param [in] comm The MPI communicator
 /// @param[in] basis The nullspace basis vectors
 /// @return A PETSc nullspace object
-MatNullSpace create_nullspace(MPI_Comm comm, const xtl::span<const Vec>& basis);
+MatNullSpace create_nullspace(MPI_Comm comm, const std::span<const Vec>& basis);
 
 /// These class provides static functions that permit users to set and
 /// retrieve PETSc options via the PETSc option/parameter system. The
@@ -287,9 +287,9 @@ public:
   static auto set_fn(Mat A, InsertMode mode)
   {
     return [A, mode, cache = std::vector<PetscInt>()](
-               const xtl::span<const std::int32_t>& rows,
-               const xtl::span<const std::int32_t>& cols,
-               const xtl::span<const PetscScalar>& vals) mutable -> int
+               const std::span<const std::int32_t>& rows,
+               const std::span<const std::int32_t>& cols,
+               const std::span<const PetscScalar>& vals) mutable -> int
     {
       PetscErrorCode ierr;
 #ifdef PETSC_USE_64BIT_INDICES
@@ -322,9 +322,9 @@ public:
   static auto set_block_fn(Mat A, InsertMode mode)
   {
     return [A, mode, cache = std::vector<PetscInt>()](
-               const xtl::span<const std::int32_t>& rows,
-               const xtl::span<const std::int32_t>& cols,
-               const xtl::span<const PetscScalar>& vals) mutable -> int
+               const std::span<const std::int32_t>& rows,
+               const std::span<const std::int32_t>& cols,
+               const std::span<const PetscScalar>& vals) mutable -> int
     {
       PetscErrorCode ierr;
 #ifdef PETSC_USE_64BIT_INDICES
@@ -361,9 +361,9 @@ public:
   {
     return [A, bs0, bs1, mode, cache0 = std::vector<PetscInt>(),
             cache1 = std::vector<PetscInt>()](
-               const xtl::span<const std::int32_t>& rows,
-               const xtl::span<const std::int32_t>& cols,
-               const xtl::span<const PetscScalar>& vals) mutable -> int
+               const std::span<const std::int32_t>& rows,
+               const std::span<const std::int32_t>& cols,
+               const std::span<const PetscScalar>& vals) mutable -> int
     {
       PetscErrorCode ierr;
       cache0.resize(bs0 * rows.size());

--- a/cpp/dolfinx/mesh/Geometry.cpp
+++ b/cpp/dolfinx/mesh/Geometry.cpp
@@ -28,9 +28,9 @@ std::shared_ptr<const common::IndexMap> Geometry::index_map() const
   return _index_map;
 }
 //-----------------------------------------------------------------------------
-xtl::span<double> Geometry::x() { return _x; }
+std::span<double> Geometry::x() { return _x; }
 //-----------------------------------------------------------------------------
-xtl::span<const double> Geometry::x() const { return _x; }
+std::span<const double> Geometry::x() const { return _x; }
 //-----------------------------------------------------------------------------
 const fem::CoordinateElement& Geometry::cmap() const { return _cmap; }
 //-----------------------------------------------------------------------------
@@ -45,7 +45,7 @@ mesh::Geometry mesh::create_geometry(
     MPI_Comm comm, const Topology& topology,
     const fem::CoordinateElement& element,
     const graph::AdjacencyList<std::int64_t>& cell_nodes,
-    const xtl::span<const double>& x, int dim,
+    const std::span<const double>& x, int dim,
     const std::function<std::vector<int>(
         const graph::AdjacencyList<std::int32_t>&)>& reorder_fn)
 {
@@ -76,7 +76,7 @@ mesh::Geometry mesh::create_geometry(
     // Build list of unique (global) node indices from adjacency list
     // (geometry nodes)
     std::vector<std::int64_t> indices = cell_nodes.array();
-    dolfinx::radix_sort(xtl::span(indices));
+    dolfinx::radix_sort(std::span(indices));
     indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
 
     //  Distribute  node coordinates by global index from other ranks.

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -11,8 +11,8 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <functional>
 #include <memory>
+#include <span>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::common
 {
@@ -80,14 +80,14 @@ public:
   ///
   /// @return The flattened row-major geometry data, where the shape is
   /// (num_points, 3)
-  xtl::span<const double> x() const;
+  std::span<const double> x() const;
 
   /// @brief Access geometry degrees-of-freedom data (non-const
   /// version).
   ///
   /// @return The flattened row-major geometry data, where the shape is
   /// (num_points, 3)
-  xtl::span<double> x();
+  std::span<double> x();
 
   /// @brief The element that describes the geometry map.
   ///
@@ -128,7 +128,8 @@ private:
 /// @param[in] topology The mesh topology
 /// @param[in] element The element that defines the geometry map for
 /// each cell
-/// @param[in] cells The mesh cells, including higher-ordder geometry 'nodes'
+/// @param[in] cells The mesh cells, including higher-order geometry
+/// 'nodes'
 /// @param[in] x The node coordinates (row-major, with shape
 /// `(num_nodes, dim)`. The global index of each node is `i +
 /// rank_offset`, where `i` is the local row index in `x` and
@@ -141,7 +142,7 @@ mesh::Geometry
 create_geometry(MPI_Comm comm, const Topology& topology,
                 const fem::CoordinateElement& element,
                 const graph::AdjacencyList<std::int64_t>& cells,
-                const xtl::span<const double>& x, int dim,
+                const std::span<const double>& x, int dim,
                 const std::function<std::vector<int>(
                     const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
                 = nullptr);

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -32,7 +32,7 @@ namespace
 template <typename T>
 graph::AdjacencyList<T>
 reorder_list(const graph::AdjacencyList<T>& list,
-             const xtl::span<const std::int32_t>& nodemap)
+             const std::span<const std::int32_t>& nodemap)
 {
   // Copy existing data to keep ghost values (not reordered)
   std::vector<T> data(list.array());
@@ -132,10 +132,10 @@ Mesh mesh::create_mesh(MPI_Comm comm,
         = cells_extracted.num_nodes() - ghost_owners.size();
     const std::vector<int> remap
         = graph::reorder_gps(std::get<0>(build_local_dual_graph(
-            xtl::span<const std::int64_t>(
+            std::span<const std::int64_t>(
                 cells_extracted.array().data(),
                 cells_extracted.offsets()[num_owned_cells]),
-            xtl::span<const std::int32_t>(cells_extracted.offsets().data(),
+            std::span<const std::int32_t>(cells_extracted.offsets().data(),
                                           num_owned_cells + 1),
             tdim)));
 
@@ -206,7 +206,7 @@ Mesh mesh::create_mesh(MPI_Comm comm,
 std::tuple<Mesh, std::vector<std::int32_t>, std::vector<std::int32_t>,
            std::vector<std::int32_t>>
 mesh::create_submesh(const Mesh& mesh, int dim,
-                     const xtl::span<const std::int32_t>& entities)
+                     const std::span<const std::int32_t>& entities)
 {
   // -- Submesh topology
 
@@ -308,7 +308,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   submesh_e_to_v_offsets.reserve(submesh_to_mesh_entity_map.size() + 1);
   for (std::int32_t e : submesh_to_mesh_entity_map)
   {
-    xtl::span<const std::int32_t> vertices = mesh_e_to_v->links(e);
+    std::span<const std::int32_t> vertices = mesh_e_to_v->links(e);
     for (std::int32_t v : vertices)
     {
       auto it = std::find(submesh_to_mesh_vertex_map.begin(),
@@ -374,7 +374,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   }
 
   // Create submesh geometry coordinates
-  xtl::span<const double> mesh_x = mesh.geometry().x();
+  std::span<const double> mesh_x = mesh.geometry().x();
   const int submesh_num_x_dofs = submesh_to_mesh_x_dof_map.size();
   std::vector<double> submesh_x(3 * submesh_num_x_dofs);
   for (int i = 0; i < submesh_num_x_dofs; ++i)

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -19,9 +19,6 @@
 #include <dolfinx/graph/ordering.h>
 #include <dolfinx/graph/partition.h>
 #include <memory>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xsort.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::mesh;
@@ -63,17 +60,19 @@ reorder_list(const graph::AdjacencyList<T>& list,
 Mesh mesh::create_mesh(MPI_Comm comm,
                        const graph::AdjacencyList<std::int64_t>& cells,
                        const fem::CoordinateElement& element,
-                       const xt::xtensor<double, 2>& x,
+                       std::span<const double> x,
+                       std::array<std::size_t, 2> xshape,
                        mesh::GhostMode ghost_mode)
 {
-  return create_mesh(comm, cells, element, x, ghost_mode,
+  return create_mesh(comm, cells, element, x, xshape, ghost_mode,
                      create_cell_partitioner());
 }
 //-----------------------------------------------------------------------------
 Mesh mesh::create_mesh(MPI_Comm comm,
                        const graph::AdjacencyList<std::int64_t>& cells,
                        const fem::CoordinateElement& element,
-                       const xt::xtensor<double, 2>& x,
+                       std::span<const double> x,
+                       std::array<std::size_t, 2> xshape,
                        mesh::GhostMode ghost_mode,
                        const mesh::CellPartitionFunction& cell_partitioner)
 {
@@ -182,8 +181,8 @@ Mesh mesh::create_mesh(MPI_Comm comm,
   }
 
   // Function top build geometry. Used to scope memory operations.
-  auto build_geometry
-      = [](auto comm, auto& cell_nodes, auto& topology, auto& element, auto& x)
+  auto build_geometry = [](auto comm, auto& cell_nodes, auto& topology,
+                           auto& element, auto& x, auto xshape1)
   {
     int tdim = topology.dim();
     int num_cells = topology.index_map(tdim)->size_local()
@@ -196,10 +195,11 @@ Mesh mesh::create_mesh(MPI_Comm comm,
     if (element.needs_dof_permutations())
       topology.create_entity_permutations();
 
-    return create_geometry(comm, topology, element, cell_nodes, x, x.shape(1));
+    return create_geometry(comm, topology, element, cell_nodes, x, xshape1);
   };
 
-  Geometry geometry = build_geometry(comm, cell_nodes, topology, element, x);
+  Geometry geometry
+      = build_geometry(comm, cell_nodes, topology, element, x, xshape[1]);
   return Mesh(comm, std::move(topology), std::move(geometry));
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -123,16 +123,19 @@ private:
 /// @param[in] element The coordinate element that describes the
 /// geometric mapping for cells
 /// @param[in] x The coordinates of mesh nodes
+/// @param[in] xshape The shape of `x`
 /// @param[in] ghost_mode The requested type of cell ghosting/overlap
 /// @return A distributed Mesh.
 Mesh create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
                  const fem::CoordinateElement& element,
-                 const xt::xtensor<double, 2>& x, GhostMode ghost_mode);
+                 std::span<const double> x, std::array<std::size_t, 2> xshape,
+                 GhostMode ghost_mode);
 
 /// Create a mesh using a provided mesh partitioning function
 Mesh create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
                  const fem::CoordinateElement& element,
-                 const xt::xtensor<double, 2>& x, GhostMode ghost_mode,
+                 std::span<const double> x, std::array<std::size_t, 2> xshape,
+                 GhostMode ghost_mode,
                  const CellPartitionFunction& cell_partitioner);
 
 /// Create a new mesh consisting of a subset of entities in a mesh.

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -145,6 +145,6 @@ Mesh create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
 std::tuple<Mesh, std::vector<std::int32_t>, std::vector<std::int32_t>,
            std::vector<std::int32_t>>
 create_submesh(const Mesh& mesh, int dim,
-               const xtl::span<const std::int32_t>& entities);
+               const std::span<const std::int32_t>& entities);
 
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -17,9 +17,9 @@
 #include <dolfinx/graph/partition.h>
 #include <dolfinx/io/cells.h>
 #include <memory>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::mesh
 {
@@ -135,7 +135,7 @@ private:
 template <typename T>
 MeshTags<T> create_meshtags(const std::shared_ptr<const Mesh>& mesh, int dim,
                             const graph::AdjacencyList<std::int32_t>& entities,
-                            const xtl::span<const T>& values)
+                            const std::span<const T>& values)
 {
   LOG(INFO)
       << "Building MeshTgas object from tagged entities (defined by vertices).";

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -41,8 +41,8 @@ namespace
 /// `edges`.
 /// @return Out edge ranks.
 /// @pre `edges` must be sorted.
-std::vector<int> find_out_edges(MPI_Comm comm, xtl::span<const int> edges,
-                                xtl::span<const int> in_edges)
+std::vector<int> find_out_edges(MPI_Comm comm, std::span<const int> edges,
+                                std::span<const int> in_edges)
 {
   std::vector<int> in_edges_neigh;
   in_edges_neigh.reserve(in_edges.size());
@@ -89,7 +89,7 @@ std::vector<int> find_out_edges(MPI_Comm comm, xtl::span<const int> edges,
 /// indices. The owner rank is the first as the first in the of ranks.
 graph::AdjacencyList<int>
 determine_sharing_ranks(MPI_Comm comm,
-                        const xtl::span<const std::int64_t>& indices)
+                        const std::span<const std::int64_t>& indices)
 {
   common::Timer timer("Topology: determine shared index ownership");
 
@@ -317,7 +317,7 @@ determine_sharing_ranks(MPI_Comm comm,
       const std::size_t d = std::distance(recv_buffer1.begin(), it);
       std::int64_t num_ranks = *it;
 
-      xtl::span ranks(recv_buffer1.data() + d + 1, num_ranks);
+      std::span ranks(recv_buffer1.data() + d + 1, num_ranks);
       data.insert(data.end(), ranks.begin(), ranks.end());
       graph_offsets.push_back(graph_offsets.back() + num_ranks);
 
@@ -354,7 +354,7 @@ vertex_ownerhip_groups(const graph::AdjacencyList<std::int64_t>& cells,
   std::vector<std::int64_t> local_vertex_set(
       cells.array().begin(),
       std::next(cells.array().begin(), cells.offsets()[num_local_cells]));
-  dolfinx::radix_sort(xtl::span(local_vertex_set));
+  dolfinx::radix_sort(std::span(local_vertex_set));
   local_vertex_set.erase(
       std::unique(local_vertex_set.begin(), local_vertex_set.end()),
       local_vertex_set.end());
@@ -363,7 +363,7 @@ vertex_ownerhip_groups(const graph::AdjacencyList<std::int64_t>& cells,
   std::vector<std::int64_t> ghost_vertex_set(
       std::next(cells.array().begin(), cells.offsets()[num_local_cells]),
       cells.array().end());
-  dolfinx::radix_sort(xtl::span(ghost_vertex_set));
+  dolfinx::radix_sort(std::span(ghost_vertex_set));
   ghost_vertex_set.erase(
       std::unique(ghost_vertex_set.begin(), ghost_vertex_set.end()),
       ghost_vertex_set.end());
@@ -414,11 +414,11 @@ vertex_ownerhip_groups(const graph::AdjacencyList<std::int64_t>& cells,
 /// 2. New global index
 /// 3. MPI rank of the owner
 std::vector<std::int64_t>
-exchange_indexing(MPI_Comm comm, const xtl::span<const std::int64_t>& indices,
+exchange_indexing(MPI_Comm comm, const std::span<const std::int64_t>& indices,
                   const graph::AdjacencyList<int>& index_to_ranks,
                   std::int64_t offset,
-                  const xtl::span<const std::int64_t>& global_indices,
-                  const xtl::span<const std::int32_t>& local_indices)
+                  const std::span<const std::int64_t>& global_indices,
+                  const std::span<const std::int32_t>& local_indices)
 {
   const int mpi_rank = dolfinx::MPI::rank(comm);
 
@@ -550,10 +550,10 @@ std::vector<std::array<std::int64_t, 3>> exchange_ghost_indexing(
     const common::IndexMap& map0,
     const graph::AdjacencyList<std::int64_t>& entities0, int nlocal1,
     std::int64_t offset1,
-    const xtl::span<const std::pair<std::int64_t, std::int32_t>>&
+    const std::span<const std::pair<std::int64_t, std::int32_t>>&
         global_local_entities1,
-    const xtl::span<const std::int64_t>& ghost_entities1,
-    const xtl::span<const int>& ghost_owners1)
+    const std::span<const std::int64_t>& ghost_entities1,
+    const std::span<const int>& ghost_owners1)
 {
   // Receive index of ghost vertices that are not on the process
   // ('true') boundary from the owner of ghost cells.
@@ -737,7 +737,7 @@ std::vector<std::array<std::int64_t, 3>> exchange_ghost_indexing(
 /// @param[in] global_to_local Sorted array of (global, local) indices.
 graph::AdjacencyList<std::int32_t> convert_to_local_indexing(
     const graph::AdjacencyList<std::int64_t>& g, std::size_t num_local_nodes,
-    const xtl::span<const std::pair<std::int64_t, std::int32_t>>&
+    const std::span<const std::pair<std::int64_t, std::int32_t>>&
         global_to_local)
 {
   std::vector<std::int32_t> offsets(
@@ -914,8 +914,8 @@ MPI_Comm Topology::comm() const { return _comm.comm(); }
 Topology
 mesh::create_topology(MPI_Comm comm,
                       const graph::AdjacencyList<std::int64_t>& cells,
-                      const xtl::span<const std::int64_t>& original_cell_index,
-                      const xtl::span<const int>& ghost_owners,
+                      const std::span<const std::int64_t>& original_cell_index,
+                      const std::span<const int>& ghost_owners,
                       const CellType& cell_type, GhostMode ghost_mode)
 {
   common::Timer timer("Topology: create");
@@ -961,12 +961,12 @@ mesh::create_topology(MPI_Comm comm,
       else
         unowned_vertices.push_back(global_index);
     }
-    dolfinx::radix_sort(xtl::span(unowned_vertices));
+    dolfinx::radix_sort(std::span(unowned_vertices));
 
     // Add owned but shared vertices to owned_vertices, and sort
     owned_vertices.insert(owned_vertices.end(), owned_shared_vertices.begin(),
                           owned_shared_vertices.end());
-    dolfinx::radix_sort(xtl::span(owned_vertices));
+    dolfinx::radix_sort(std::span(owned_vertices));
   }
 
   // Number all owned vertices, iterating over vertices cell-wise
@@ -1004,17 +1004,17 @@ mesh::create_topology(MPI_Comm comm,
   else
   {
     // Get global indices of ghost cells
-    xtl::span cell_idx(original_cell_index);
+    std::span cell_idx(original_cell_index);
     const std::vector cell_ghost_indices = graph::build::compute_ghost_indices(
         comm, cell_idx.first(cells.num_nodes() - ghost_owners.size()),
-        xtl::span(original_cell_index).last(ghost_owners.size()), ghost_owners);
+        std::span(original_cell_index).last(ghost_owners.size()), ghost_owners);
 
     // Build list of owner ranks for vertices on the 'true boundary'
     // between processes. This is a superset of the ranks that own ghost
     // cells.
     std::vector<int> ranks(global_vertex_to_ranks.array().begin(),
                            global_vertex_to_ranks.array().end());
-    dolfinx::radix_sort(xtl::span(ranks));
+    dolfinx::radix_sort(std::span(ranks));
     ranks.erase(std::unique(ranks.begin(), ranks.end()), ranks.end());
 
     // List of ranks that own cells that are ghosts on this rank
@@ -1166,7 +1166,7 @@ mesh::create_topology(MPI_Comm comm,
     // Build list of ranks that own vertices that are ghosted by this
     // rank (out edges)
     std::vector<int> src = ghost_vertex_owners;
-    dolfinx::radix_sort(xtl::span(src));
+    dolfinx::radix_sort(std::span(src));
     src.erase(std::unique(src.begin(), src.end()), src.end());
     dest = dolfinx::MPI::compute_graph_edges_nbx(comm, src);
   }

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -10,8 +10,8 @@
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <memory>
+#include <span>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::common
 {
@@ -181,8 +181,8 @@ private:
 /// @return A distributed mesh topology
 Topology
 create_topology(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
-                const xtl::span<const std::int64_t>& original_cell_index,
-                const xtl::span<const int>& ghost_owners,
+                const std::span<const std::int64_t>& original_cell_index,
+                const std::span<const int>& ghost_owners,
                 const CellType& cell_type, GhostMode ghost_mode);
 
 /// @brief Get entity indices for entities defined by their vertices.

--- a/cpp/dolfinx/mesh/cell_types.cpp
+++ b/cpp/dolfinx/mesh/cell_types.cpp
@@ -10,9 +10,6 @@
 #include <cfloat>
 #include <cstdlib>
 #include <stdexcept>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xfixed.hpp>
-#include <xtensor/xtensor.hpp>
 
 using namespace dolfinx;
 

--- a/cpp/dolfinx/mesh/generation.cpp
+++ b/cpp/dolfinx/mesh/generation.cpp
@@ -5,13 +5,14 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "generation.h"
+#include <array>
 #include <cfloat>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/graph/AdjacencyList.h>
-#include <xtensor/xfixed.hpp>
+#include <vector>
+#include <xtensor/xadapt.hpp>
 #include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::mesh;
@@ -19,13 +20,13 @@ using namespace dolfinx::mesh;
 namespace
 {
 //-----------------------------------------------------------------------------
-xt::xtensor<double, 2>
-create_geom(MPI_Comm comm, const std::array<std::array<double, 3>, 2>& p,
-            std::array<std::size_t, 3> n)
+std::vector<double> create_geom(MPI_Comm comm,
+                                const std::array<std::array<double, 3>, 2>& p,
+                                std::array<std::size_t, 3> n)
 {
   // Extract data
-  const std::array<double, 3>& p0 = p[0];
-  const std::array<double, 3>& p1 = p[1];
+  const std::array<double, 3> p0 = p[0];
+  const std::array<double, 3> p1 = p[1];
   std::int64_t nx = n[0];
   std::int64_t ny = n[1];
   std::int64_t nz = n[2];
@@ -66,8 +67,7 @@ create_geom(MPI_Comm comm, const std::array<std::array<double, 3>, 2>& p,
         "BoxMesh has non-positive number of vertices in some dimension");
   }
 
-  xt::xtensor<double, 2> geom(
-      {static_cast<std::size_t>(range_p[1] - range_p[0]), 3});
+  std::vector<double> geom((range_p[1] - range_p[0]) * 3);
   const std::int64_t sqxy = (nx + 1) * (ny + 1);
   std::array<double, 3> point;
   for (std::int64_t v = range_p[0]; v < range_p[1]; ++v)
@@ -81,7 +81,7 @@ create_geom(MPI_Comm comm, const std::array<std::array<double, 3>, 2>& p,
     const double x = a + ab * static_cast<double>(ix);
     point = {x, y, z};
     for (std::size_t i = 0; i < 3; i++)
-      geom(v - range_p[0], i) = point[i];
+      geom[3 * (v - range_p[0]) + i] = point[i];
   }
 
   return geom;
@@ -94,7 +94,7 @@ mesh::Mesh build_tet(MPI_Comm comm,
 {
   common::Timer timer("Build BoxMesh");
 
-  xt::xtensor<double, 2> geom = create_geom(comm, p, n);
+  std::vector<double> geom = create_geom(comm, p, n);
 
   const std::int64_t nx = n[0];
   const std::int64_t ny = n[1];
@@ -103,7 +103,7 @@ mesh::Mesh build_tet(MPI_Comm comm,
   std::array range_c = dolfinx::MPI::local_range(
       dolfinx::MPI::rank(comm), n_cells, dolfinx::MPI::size(comm));
   const std::size_t cell_range = range_c[1] - range_c[0];
-  xt::xtensor<std::int64_t, 2> cells({6 * cell_range, 4});
+  std::vector<std::int64_t> cells(6 * cell_range * 4);
 
   // Create tetrahedra
   for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
@@ -123,24 +123,18 @@ mesh::Mesh build_tet(MPI_Comm comm,
     const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
 
     // Note that v0 < v1 < v2 < v3 < vmid
-    xt::xtensor_fixed<std::int64_t, xt::xshape<6, 4>> c
-        = {{v0, v1, v3, v7}, {v0, v1, v7, v5}, {v0, v5, v7, v4},
-           {v0, v3, v2, v7}, {v0, v6, v4, v7}, {v0, v2, v6, v7}};
+    std::array<std::int64_t, 24> c
+        = {v0, v1, v3, v7, v0, v1, v7, v5, v0, v5, v7, v4,
+           v0, v3, v2, v7, v0, v6, v4, v7, v0, v2, v6, v7};
     std::size_t offset = 6 * (i - range_c[0]);
-
-    // Note: we would like to assign to a view, but this does not work
-    // correctly with the Intel icpx compiler
-    // xt::view(cells, xt::range(offset, offset + 6), xt::all()) = c;
-    auto _cell = xt::view(cells, xt::range(offset, offset + 6), xt::all());
-    _cell.assign(c);
+    std::copy(c.begin(), c.end(), std::next(cells.begin(), 4 * offset));
   }
 
+  auto _geom = xt::adapt(geom, std::vector<std::size_t>{geom.size() / 3, 3});
+
   fem::CoordinateElement element(CellType::tetrahedron, 1);
-  auto [data, offset] = graph::create_adjacency_data(cells);
-  return create_mesh(
-      comm,
-      graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
-      element, geom, ghost_mode, partitioner);
+  return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 4),
+                     element, _geom, ghost_mode, partitioner);
 }
 //-----------------------------------------------------------------------------
 mesh::Mesh build_hex(MPI_Comm comm,
@@ -148,7 +142,7 @@ mesh::Mesh build_hex(MPI_Comm comm,
                      std::array<std::size_t, 3> n, GhostMode ghost_mode,
                      const CellPartitionFunction& partitioner)
 {
-  xt::xtensor<double, 2> geom = create_geom(comm, p, n);
+  std::vector<double> geom = create_geom(comm, p, n);
 
   const std::int64_t nx = n[0];
   const std::int64_t ny = n[1];
@@ -157,7 +151,7 @@ mesh::Mesh build_hex(MPI_Comm comm,
   std::array range_c = dolfinx::MPI::local_range(
       dolfinx::MPI::rank(comm), n_cells, dolfinx::MPI::size(comm));
   const std::size_t cell_range = range_c[1] - range_c[0];
-  xt::xtensor<std::int64_t, 2> cells({cell_range, 8});
+  std::vector<std::int64_t> cells(cell_range * 8);
 
   // Create cuboids
   for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
@@ -176,21 +170,15 @@ mesh::Mesh build_hex(MPI_Comm comm,
     const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
     const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
 
-    xt::xtensor_fixed<std::int64_t, xt::xshape<8>> cell
-        = {v0, v1, v2, v3, v4, v5, v6, v7};
-    // Note: we would like to assign to a view, but this does not work
-    // correctly with the Intel icpx compiler
-    // _cell = xt::row(cells, i - range_c[0]) = c;
-    auto _cell = xt::row(cells, i - range_c[0]);
-    _cell.assign(cell);
+    std::array<std::int64_t, 8> c = {v0, v1, v2, v3, v4, v5, v6, v7};
+    std::copy(c.begin(), c.end(),
+              std::next(cells.begin(), (i - range_c[0]) * 8));
   }
 
+  auto _geom = xt::adapt(geom, std::vector<std::size_t>{geom.size() / 3, 3});
   fem::CoordinateElement element(CellType::hexahedron, 1);
-  auto [data, offset] = graph::create_adjacency_data(cells);
-  return create_mesh(
-      comm,
-      graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
-      element, geom, ghost_mode, partitioner);
+  return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 8),
+                     element, _geom, ghost_mode, partitioner);
 }
 //-----------------------------------------------------------------------------
 mesh::Mesh build_prism(MPI_Comm comm,
@@ -198,7 +186,7 @@ mesh::Mesh build_prism(MPI_Comm comm,
                        std::array<std::size_t, 3> n, GhostMode ghost_mode,
                        const CellPartitionFunction& partitioner)
 {
-  xt::xtensor<double, 2> geom = create_geom(comm, p, n);
+  std::vector<double> geom = create_geom(comm, p, n);
 
   const std::int64_t nx = n[0];
   const std::int64_t ny = n[1];
@@ -207,7 +195,7 @@ mesh::Mesh build_prism(MPI_Comm comm,
   std::array range_c = dolfinx::MPI::local_range(
       dolfinx::MPI::rank(comm), n_cells, dolfinx::MPI::size(comm));
   const std::size_t cell_range = range_c[1] - range_c[0];
-  xt::xtensor<std::int64_t, 2> cells({cell_range * 2, 6});
+  std::vector<std::int64_t> cells(2 * cell_range * 6);
 
   // Create cuboids
   for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
@@ -226,21 +214,19 @@ mesh::Mesh build_prism(MPI_Comm comm,
     const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
     const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
 
-    xt::xtensor_fixed<std::int64_t, xt::xshape<6>> cell0
-        = {v0, v1, v2, v4, v5, v6};
-    xt::xtensor_fixed<std::int64_t, xt::xshape<6>> cell1
-        = {v1, v2, v3, v5, v6, v7};
+    std::array<std::int64_t, 6> c0 = {v0, v1, v2, v4, v5, v6};
+    std::array<std::int64_t, 6> c1 = {v1, v2, v3, v5, v6, v7};
 
-    xt::view(cells, (i - range_c[0]) * 2, xt::all()) = cell0;
-    xt::view(cells, (i - range_c[0]) * 2 + 1, xt::all()) = cell1;
+    std::copy(c0.begin(), c0.end(),
+              std::next(cells.begin(), 6 * ((i - range_c[0]) * 2)));
+    std::copy(c1.begin(), c1.end(),
+              std::next(cells.begin(), 6 * ((i - range_c[0]) * 2 + 1)));
   }
 
+  auto _geom = xt::adapt(geom, std::vector<std::size_t>{geom.size() / 3, 3});
   fem::CoordinateElement element(CellType::prism, 1);
-  auto [data, offset] = graph::create_adjacency_data(cells);
-  return create_mesh(
-      comm,
-      graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
-      element, geom, ghost_mode, partitioner);
+  return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 6),
+                     element, _geom, ghost_mode, partitioner);
 }
 //-----------------------------------------------------------------------------
 
@@ -277,11 +263,8 @@ mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
   if (dolfinx::MPI::rank(comm) != 0)
   {
     xt::xtensor<double, 2> geom({0, 1});
-    xt::xtensor<std::int64_t, 2> cells({0, 2});
-    auto [data, offset] = graph::create_adjacency_data(cells);
     return create_mesh(
-        comm,
-        graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
+        comm, graph::regular_adjacency_list(std::vector<std::int64_t>(), 2),
         element, geom, ghost_mode, partitioner);
   }
 
@@ -310,16 +293,13 @@ mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
     geom(ix, 0) = a + ab * static_cast<double>(ix);
 
   // Create intervals
-  xt::xtensor<std::int64_t, 2> cells({nx, 2});
+  std::vector<std::int64_t> cells(nx * 2);
   for (std::size_t ix = 0; ix < nx; ++ix)
     for (std::size_t j = 0; j < 2; ++j)
-      cells(ix, j) = ix + j;
+      cells[2 * ix + j] = ix + j;
 
-  auto [data, offset] = graph::create_adjacency_data(cells);
-  return create_mesh(
-      comm,
-      graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
-      element, geom, ghost_mode, partitioner);
+  return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 2),
+                     element, geom, ghost_mode, partitioner);
 }
 } // namespace
 
@@ -346,11 +326,8 @@ mesh::Mesh build_tri(MPI_Comm comm,
   if (dolfinx::MPI::rank(comm) != 0)
   {
     xt::xtensor<double, 2> geom({0, 2});
-    xt::xtensor<std::int64_t, 2> cells({0, 3});
-    auto [data, offset] = graph::create_adjacency_data(cells);
     return create_mesh(
-        comm,
-        graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
+        comm, graph::regular_adjacency_list(std::vector<std::int64_t>(), 3),
         element, geom, ghost_mode, partitioner);
   }
 
@@ -400,7 +377,7 @@ mesh::Mesh build_tri(MPI_Comm comm,
   }
 
   xt::xtensor<double, 2> geom({nv, 2});
-  xt::xtensor<std::int64_t, 2> cells({nc, 3});
+  std::vector<std::int64_t> cells(nc * 3);
 
   // Create main vertices
   std::size_t vertex = 0;
@@ -450,17 +427,10 @@ mesh::Mesh build_tri(MPI_Comm comm,
         const std::size_t vmid = (nx + 1) * (ny + 1) + iy * nx + ix;
 
         // Note that v0 < v1 < v2 < v3 < vmid
-        xt::xtensor_fixed<std::size_t, xt::xshape<4, 3>> c
-            = {{v0, v1, vmid}, {v0, v2, vmid}, {v1, v3, vmid}, {v2, v3, vmid}};
+        std::array<std::size_t, 12> c
+            = {v0, v1, vmid, v0, v2, vmid, v1, v3, vmid, v2, v3, vmid};
         std::size_t offset = iy * nx + ix;
-
-        // Note: we would like to assign to a view, but this does not
-        // work correctly with the Intel icpx compiler
-        // xt::view(cells, xt::range(4 * offset, 4 * offset + 4), xt::all()) =
-        // c;
-        auto _cell
-            = xt::view(cells, xt::range(4 * offset, 4 * offset + 4), xt::all());
-        _cell.assign(c);
+        std::copy(c.begin(), c.end(), std::next(cells.begin(), 4 * offset * 3));
       }
     }
     break;
@@ -500,16 +470,9 @@ mesh::Mesh build_tri(MPI_Comm comm,
         {
         case DiagonalType::left:
         {
-          xt::xtensor_fixed<std::size_t, xt::xshape<2, 3>> c
-              = {{v0, v1, v2}, {v1, v2, v3}};
-          // Note: we would like to assign to a view, but this does not
-          // work correctly with the Intel icpx compiler
-          // xt::view(cells, xt::range(2 * offset, 2 * offset + 2), xt::all()) =
-          // c;
-          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2),
-                                xt::all());
-          _cell.assign(c);
-
+          std::array<std::size_t, 6> c = {v0, v1, v2, v1, v2, v3};
+          std::copy(c.begin(), c.end(),
+                    std::next(cells.begin(), 2 * offset * 3));
           if (diagonal == DiagonalType::right_left
               or diagonal == DiagonalType::left_right)
           {
@@ -519,15 +482,9 @@ mesh::Mesh build_tri(MPI_Comm comm,
         }
         default:
         {
-          xt::xtensor_fixed<std::size_t, xt::xshape<2, 3>> c
-              = {{v0, v1, v3}, {v0, v2, v3}};
-          // Note: we would like to assign to a view, but this does not
-          // work correctly with the Intel icpx compiler
-          // xt::view(cells, xt::range(2 * offset, 2 * offset + 2), xt::all()) =
-          // c;
-          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2),
-                                xt::all());
-          _cell.assign(c);
+          std::array<std::size_t, 6> c = {v0, v1, v3, v0, v2, v3};
+          std::copy(c.begin(), c.end(),
+                    std::next(cells.begin(), 2 * offset * 3));
           if (diagonal == DiagonalType::right_left
               or diagonal == DiagonalType::left_right)
           {
@@ -540,11 +497,8 @@ mesh::Mesh build_tri(MPI_Comm comm,
   }
   }
 
-  auto [data, offset] = graph::create_adjacency_data(cells);
-  return create_mesh(
-      comm,
-      graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
-      element, geom, ghost_mode, partitioner);
+  return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 3),
+                     element, geom, ghost_mode, partitioner);
 }
 
 //-----------------------------------------------------------------------------
@@ -559,11 +513,8 @@ mesh::Mesh build_quad(MPI_Comm comm,
   if (dolfinx::MPI::rank(comm) != 0)
   {
     xt::xtensor<double, 2> geom({0, 2});
-    xt::xtensor<std::int64_t, 2> cells({0, 4});
-    auto [data, offset] = graph::create_adjacency_data(cells);
     return create_mesh(
-        comm,
-        graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
+        comm, graph::regular_adjacency_list(std::vector<std::int64_t>(), 4),
         element, geom, ghost_mode, partitioner);
   }
 
@@ -593,28 +544,21 @@ mesh::Mesh build_quad(MPI_Comm comm,
   }
 
   // Create rectangles
-  xt::xtensor<std::int64_t, 2> cells({nx * ny, 4});
+  std::vector<std::int64_t> cells(nx * ny * 4);
   for (std::size_t ix = 0; ix < nx; ix++)
   {
     for (std::size_t iy = 0; iy < ny; iy++)
     {
       const std::size_t i0 = ix * (ny + 1);
       std::size_t cell = ix * ny + iy;
-      xt::xtensor_fixed<std::size_t, xt::xshape<4>> c
+      std::array<std::size_t, 4> c
           = {i0 + iy, i0 + iy + 1, i0 + iy + ny + 1, i0 + iy + ny + 2};
-      // Note: we would like to assign to a view, but this does not
-      // work correctly with the Intel icpx compiler
-      // xt::row(cells, cell) = c;
-      auto _cell = xt::row(cells, cell);
-      _cell.assign(c);
+      std::copy(c.begin(), c.end(), std::next(cells.begin(), 4 * cell));
     }
   }
 
-  auto [data, offset] = graph::create_adjacency_data(cells);
-  return create_mesh(
-      comm,
-      graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
-      element, geom, ghost_mode, partitioner);
+  return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 4),
+                     element, geom, ghost_mode, partitioner);
 }
 } // namespace
 

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -12,9 +12,9 @@
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/sort.h>
 #include <dolfinx/graph/AdjacencyList.h>
+#include <span>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 using namespace dolfinx;
 
@@ -82,8 +82,8 @@ constexpr mesh::CellType get_cell_type(int num_vertices, int tdim)
 /// @return (0) Extended dual graph to include ghost edges (edges to
 /// off-procss cells) and (1) the number of ghost edges
 graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
-    const MPI_Comm comm, const xtl::span<const std::int64_t>& facets,
-    std::size_t shape1, const xtl::span<const std::int32_t>& cells,
+    const MPI_Comm comm, const std::span<const std::int64_t>& facets,
+    std::size_t shape1, const std::span<const std::int32_t>& cells,
     const graph::AdjacencyList<std::int32_t>& local_graph)
 {
   LOG(INFO) << "Build nonlocal part of mesh dual graph";
@@ -364,7 +364,7 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
     {
       auto e = local_graph.links(i);
       disp[i] += e.size();
-      std::transform(e.cbegin(), e.cend(), std::next(data.begin(), offsets[i]),
+      std::transform(e.begin(), e.end(), std::next(data.begin(), offsets[i]),
                      [cell_offset](auto x) { return x + cell_offset; });
     }
 
@@ -389,8 +389,8 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
 //-----------------------------------------------------------------------------
 std::tuple<graph::AdjacencyList<std::int32_t>, std::vector<std::int64_t>,
            std::size_t, std::vector<std::int32_t>>
-mesh::build_local_dual_graph(const xtl::span<const std::int64_t>& cell_vertices,
-                             const xtl::span<const std::int32_t>& cell_offsets,
+mesh::build_local_dual_graph(const std::span<const std::int64_t>& cell_vertices,
+                             const std::span<const std::int32_t>& cell_offsets,
                              int tdim)
 {
   LOG(INFO) << "Build local part of mesh dual graph";
@@ -465,7 +465,7 @@ mesh::build_local_dual_graph(const xtl::span<const std::int64_t>& cell_vertices,
     auto it = perm.begin();
     while (it != perm.end())
     {
-      auto f0 = xtl::span(facets.data() + (*it) * shape1, shape1);
+      auto f0 = std::span(facets.data() + (*it) * shape1, shape1);
 
       // Find iterator to next facet different from f0
       auto it1 = std::find_if_not(
@@ -481,7 +481,7 @@ mesh::build_local_dual_graph(const xtl::span<const std::int64_t>& cell_vertices,
       std::int32_t cell0 = f0.back();
       for (auto itx = std::next(it); itx != it1; ++itx)
       {
-        auto f1 = xtl::span(facets.data() + *itx * shape1, shape1);
+        auto f1 = std::span(facets.data() + *itx * shape1, shape1);
         std::int32_t cell1 = f1.back();
         edges.push_back({cell0, cell1});
       }

--- a/cpp/dolfinx/mesh/graphbuild.h
+++ b/cpp/dolfinx/mesh/graphbuild.h
@@ -8,9 +8,9 @@
 
 #include <cstdint>
 #include <mpi.h>
+#include <span>
 #include <tuple>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::graph
 {
@@ -42,8 +42,8 @@ namespace dolfinx::mesh
 /// topology meshes.
 std::tuple<graph::AdjacencyList<std::int32_t>, std::vector<std::int64_t>,
            std::size_t, std::vector<std::int32_t>>
-build_local_dual_graph(const xtl::span<const std::int64_t>& cells,
-                       const xtl::span<const std::int32_t>& offsets, int tdim);
+build_local_dual_graph(const std::span<const std::int64_t>& cells,
+                       const std::span<const std::int32_t>& offsets, int tdim);
 
 /// @brief Build distributed mesh dual graph (cell-cell connections via
 /// facets) from minimal mesh data.

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -99,9 +99,9 @@ int get_ownership(const U& processes, const V& vertices)
 std::tuple<std::vector<int>, common::IndexMap>
 get_local_indexing(MPI_Comm comm, const common::IndexMap& cell_map,
                    const common::IndexMap& vertex_map,
-                   const xtl::span<const std::int32_t>& entity_list,
+                   const std::span<const std::int32_t>& entity_list,
                    int num_vertices_per_e, int num_entities_per_cell,
-                   const xtl::span<const std::int32_t>& entity_index)
+                   const std::span<const std::int32_t>& entity_index)
 {
   // entity_list contains all the entities for all the cells, listed as
   // local vertex indices, and entity_index contains the initial
@@ -190,7 +190,7 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& cell_map,
     {
       // Get entity vertices
       std::size_t pos = std::distance(entity_index.begin(), entity_idx);
-      xtl::span entity
+      std::span entity
           = entity_list.subspan(pos * num_vertices_per_e, num_vertices_per_e);
 
       // Build list of ranks that share vertices of the entity, and sort
@@ -315,7 +315,7 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& cell_map,
     // Loop over received entities (defined by array of entity vertices)
     for (int j = recv_disp[r]; j < recv_disp[r + 1]; j += num_vertices_per_e)
     {
-      xtl::span<const std::int64_t> entity(recv_data.data() + j,
+      std::span<const std::int64_t> entity(recv_data.data() + j,
                                            num_vertices_per_e);
       auto it = std::lower_bound(
           perm.begin(), perm.end(), entity,
@@ -330,7 +330,7 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& cell_map,
       if (it != perm.end())
       {
         auto offset = (*it) * (num_vertices_per_e + 1);
-        xtl::span<const std::int64_t> e(entity_to_local_idx.data() + offset,
+        std::span<const std::int64_t> e(entity_to_local_idx.data() + offset,
                                         num_vertices_per_e + 1);
         if (std::equal(e.begin(), std::prev(e.end()), entity.begin()))
         {
@@ -469,7 +469,7 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& cell_map,
 
   // Create map from initial numbering to new local indices
   std::vector<std::int32_t> new_entity_index(entity_index.size());
-  std::transform(entity_index.cbegin(), entity_index.cend(),
+  std::transform(entity_index.begin(), entity_index.end(),
                  new_entity_index.begin(),
                  [&local_index](auto index) { return local_index[index]; });
 
@@ -564,7 +564,7 @@ compute_entities_by_key_matching(
     {
       // First entity in new index range
       std::size_t offset = (*it) * max_vertices_per_entity;
-      xtl::span e0(entity_list_sorted.data() + offset, max_vertices_per_entity);
+      std::span e0(entity_list_sorted.data() + offset, max_vertices_per_entity);
 
       // Find iterator to next entity
       auto it1 = std::find_if_not(
@@ -572,7 +572,7 @@ compute_entities_by_key_matching(
           [e0, &entity_list_sorted, max_vertices_per_entity](auto idx) -> bool
           {
             std::size_t offset = idx * max_vertices_per_entity;
-            return std::equal(e0.cbegin(), e0.cend(),
+            return std::equal(e0.begin(), e0.end(),
                               std::next(entity_list_sorted.begin(), offset));
           });
 
@@ -696,7 +696,7 @@ compute_from_map(const graph::AdjacencyList<std::int32_t>& c_d0_0,
   std::array<std::int32_t, 2> key;
   for (int e = 0; e < c_d1_0.num_nodes(); ++e)
   {
-    xtl::span<const std::int32_t> v = c_d1_0.links(e);
+    std::span<const std::int32_t> v = c_d1_0.links(e);
     assert(v.size() == key.size());
     std::partial_sort_copy(v.begin(), v.end(), key.begin(), key.end());
     edge_to_index.insert({key, e});

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -55,7 +55,7 @@ mesh::extract_topology(const CellType& cell_type,
 }
 //-----------------------------------------------------------------------------
 std::vector<double> mesh::h(const Mesh& mesh,
-                            const xtl::span<const std::int32_t>& entities,
+                            const std::span<const std::int32_t>& entities,
                             int dim)
 {
   if (entities.empty())
@@ -70,7 +70,7 @@ std::vector<double> mesh::h(const Mesh& mesh,
   const std::size_t num_vertices = vertex_xdofs.size() / entities.size();
 
   // Get the  geometry coordinate
-  const xtl::span<const double> x = mesh.geometry().x();
+  const std::span<const double> x = mesh.geometry().x();
 
   // Function to compute the length of (p0 - p1)
   auto delta_norm = [](const auto& p0, const auto& p1)
@@ -87,16 +87,16 @@ std::vector<double> mesh::h(const Mesh& mesh,
   for (std::size_t e = 0; e < entities.size(); ++e)
   {
     // Get geometry 'dof' for each vertex of entity e
-    xtl::span<const std::int32_t> e_vertices(
+    std::span<const std::int32_t> e_vertices(
         vertex_xdofs.data() + e * num_vertices, num_vertices);
 
     // Compute maximum distance between any two vertices
     for (std::size_t i = 0; i < e_vertices.size(); ++i)
     {
-      xtl::span<const double, 3> p0(x.data() + 3 * e_vertices[i], 3);
+      std::span<const double, 3> p0(x.data() + 3 * e_vertices[i], 3);
       for (std::size_t j = i + 1; j < e_vertices.size(); ++j)
       {
-        xtl::span<const double, 3> p1(x.data() + 3 * e_vertices[j], 3);
+        std::span<const double, 3> p1(x.data() + 3 * e_vertices[j], 3);
         h[e] = std::max(h[e], delta_norm(p0, p1));
       }
     }
@@ -107,7 +107,7 @@ std::vector<double> mesh::h(const Mesh& mesh,
 //-----------------------------------------------------------------------------
 std::vector<double>
 mesh::cell_normals(const mesh::Mesh& mesh, int dim,
-                   const xtl::span<const std::int32_t>& entities)
+                   const std::span<const std::int32_t>& entities)
 {
   if (entities.empty())
     return std::vector<double>();
@@ -119,7 +119,7 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
   const CellType type = cell_entity_type(mesh.topology().cell_type(), dim, 0);
 
   // Find geometry nodes for topology entities
-  xtl::span<const double> x = mesh.geometry().x();
+  std::span<const double> x = mesh.geometry().x();
 
   // Orient cells if they are tetrahedron
   bool orient = false;
@@ -143,8 +143,8 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
       std::array vertices{geometry_entities[i * shape1],
                           geometry_entities[i * shape1 + 1]};
       std::array p
-          = {xtl::span<const double, 3>(x.data() + 3 * vertices[0], 3),
-             xtl::span<const double, 3>(x.data() + 3 * vertices[1], 3)};
+          = {std::span<const double, 3>(x.data() + 3 * vertices[0], 3),
+             std::span<const double, 3>(x.data() + 3 * vertices[1], 3)};
 
       // Define normal by rotating tangent counter-clockwise
       std::array<double, 3> t;
@@ -152,7 +152,7 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
                      [](auto x, auto y) { return x - y; });
 
       double norm = std::sqrt(t[0] * t[0] + t[1] * t[1]);
-      xtl::span<double, 3> ni(n.data() + 3 * i, 3);
+      std::span<double, 3> ni(n.data() + 3 * i, 3);
       ni[0] = -t[1] / norm;
       ni[1] = t[0] / norm;
       ni[2] = 0.0;
@@ -168,9 +168,9 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
                              geometry_entities[i * shape1 + 1],
                              geometry_entities[i * shape1 + 2]};
       std::array p
-          = {xtl::span<const double, 3>(x.data() + 3 * vertices[0], 3),
-             xtl::span<const double, 3>(x.data() + 3 * vertices[1], 3),
-             xtl::span<const double, 3>(x.data() + 3 * vertices[2], 3)};
+          = {std::span<const double, 3>(x.data() + 3 * vertices[0], 3),
+             std::span<const double, 3>(x.data() + 3 * vertices[1], 3),
+             std::span<const double, 3>(x.data() + 3 * vertices[2], 3)};
 
       // Compute (p1 - p0) and (p2 - p0)
       std::array<double, 3> dp1, dp2;
@@ -180,7 +180,7 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
                      [](auto x, auto y) { return x - y; });
 
       // Define cell normal via cross product of first two edges
-      std::array<double, 3> ni = math::cross_new(dp1, dp2);
+      std::array<double, 3> ni = math::cross(dp1, dp2);
       double norm = std::sqrt(ni[0] * ni[0] + ni[1] * ni[1] + ni[2] * ni[2]);
       std::transform(ni.begin(), ni.end(), std::next(n.begin(), 3 * i),
                      [norm](auto x) { return x / norm; });
@@ -197,9 +197,9 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
                              geometry_entities[i * shape1 + 1],
                              geometry_entities[i * shape1 + 2]};
       std::array p
-          = {xtl::span<const double, 3>(x.data() + 3 * vertices[0], 3),
-             xtl::span<const double, 3>(x.data() + 3 * vertices[1], 3),
-             xtl::span<const double, 3>(x.data() + 3 * vertices[2], 3)};
+          = {std::span<const double, 3>(x.data() + 3 * vertices[0], 3),
+             std::span<const double, 3>(x.data() + 3 * vertices[1], 3),
+             std::span<const double, 3>(x.data() + 3 * vertices[2], 3)};
 
       // Compute (p1 - p0) and (p2 - p0)
       std::array<double, 3> dp1, dp2;
@@ -209,7 +209,7 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
                      [](auto x, auto y) { return x - y; });
 
       // Define cell normal via cross product of first two edges
-      std::array<double, 3> ni = math::cross_new(dp1, dp2);
+      std::array<double, 3> ni = math::cross(dp1, dp2);
       double norm = std::sqrt(ni[0] * ni[0] + ni[1] * ni[1] + ni[2] * ni[2]);
       std::transform(ni.begin(), ni.end(), std::next(n.begin(), 3 * i),
                      [norm](auto x) { return x / norm; });
@@ -224,12 +224,12 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
 //-----------------------------------------------------------------------------
 std::vector<double>
 mesh::compute_midpoints(const Mesh& mesh, int dim,
-                        const xtl::span<const std::int32_t>& entities)
+                        const std::span<const std::int32_t>& entities)
 {
   if (entities.empty())
     return std::vector<double>();
 
-  xtl::span<const double> x = mesh.geometry().x();
+  std::span<const double> x = mesh.geometry().x();
 
   // Build map from entity -> geometry dof
   // FIXME: This assumes a linear geometry.
@@ -240,11 +240,11 @@ mesh::compute_midpoints(const Mesh& mesh, int dim,
   std::vector<double> x_mid(entities.size() * 3, 0);
   for (std::size_t e = 0; e < entities.size(); ++e)
   {
-    xtl::span<double, 3> p(x_mid.data() + 3 * e, 3);
-    xtl::span<const std::int32_t> rows(e_to_g.data() + e * shape1, shape1);
+    std::span<double, 3> p(x_mid.data() + 3 * e, 3);
+    std::span<const std::int32_t> rows(e_to_g.data() + e * shape1, shape1);
     for (auto row : rows)
     {
-      xtl::span<const double, 3> xg(x.data() + 3 * row, 3);
+      std::span<const double, 3> xg(x.data() + 3 * row, 3);
       std::transform(p.begin(), p.end(), xg.begin(), p.begin(),
                      [size = rows.size()](auto x, auto y)
                      { return x + y / size; });
@@ -284,7 +284,7 @@ std::vector<std::int32_t> mesh::locate_entities(
   }
 
   // Pack coordinates of vertices
-  xtl::span<const double> x_nodes = mesh.geometry().x();
+  std::span<const double> x_nodes = mesh.geometry().x();
   xt::xtensor<double, 2> x_vertices({3, vertex_to_node.size()});
   for (std::size_t i = 0; i < vertex_to_node.size(); ++i)
   {
@@ -375,7 +375,7 @@ std::vector<std::int32_t> mesh::locate_entities_boundary(
 
   // Get geometry data
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
-  xtl::span<const double> x_nodes = mesh.geometry().x();
+  std::span<const double> x_nodes = mesh.geometry().x();
 
   // Get all vertex 'node' indices
   auto v_to_c = topology.connectivity(0, tdim);
@@ -437,7 +437,7 @@ std::vector<std::int32_t> mesh::locate_entities_boundary(
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t>
 mesh::entities_to_geometry(const Mesh& mesh, int dim,
-                           const xtl::span<const std::int32_t>& entities,
+                           const std::span<const std::int32_t>& entities,
                            bool orient)
 {
   CellType cell_type = mesh.topology().cell_type();
@@ -580,7 +580,7 @@ mesh::create_cell_partitioner(const graph::partition_fn& partfn)
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t>
 mesh::compute_incident_entities(const Mesh& mesh,
-                                const xtl::span<const std::int32_t>& entities,
+                                const std::span<const std::int32_t>& entities,
                                 int d0, int d1)
 {
   auto map0 = mesh.topology().index_map(d0);

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -10,8 +10,8 @@
 #include <dolfinx/graph/partition.h>
 #include <functional>
 #include <mpi.h>
+#include <span>
 #include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::fem
 {
@@ -75,20 +75,20 @@ extract_topology(const CellType& cell_type, const fem::ElementDofLayout& layout,
 /// @returns The greatest distance between any two vertices, `h[i]`
 /// corresponds to the entity `entities[i]`.
 std::vector<double> h(const Mesh& mesh,
-                      const xtl::span<const std::int32_t>& entities, int dim);
+                      const std::span<const std::int32_t>& entities, int dim);
 
 /// @brief Compute normal to given cell (viewed as embedded in 3D)
 /// @returns The entity normals. The shape is `(entities.size(), 3)` and
 /// the storage is row-major.
 std::vector<double> cell_normals(const Mesh& mesh, int dim,
-                                 const xtl::span<const std::int32_t>& entities);
+                                 const std::span<const std::int32_t>& entities);
 
 /// @brief Compute the midpoints for mesh entities of a given dimension.
 /// @returns The entity midpoints. The shape is `(entities.size(), 3)`
 /// and the storage is row-major.
 std::vector<double>
 compute_midpoints(const Mesh& mesh, int dim,
-                  const xtl::span<const std::int32_t>& entities);
+                  const std::span<const std::int32_t>& entities);
 
 /// Compute indices of all mesh entities that evaluate to true for the
 /// provided geometric marking function. An entity is considered marked
@@ -148,7 +148,7 @@ std::vector<std::int32_t> locate_entities_boundary(
 /// geometry array of the `j`-th vertex of the `entity[i]`.
 std::vector<std::int32_t>
 entities_to_geometry(const Mesh& mesh, int dim,
-                     const xtl::span<const std::int32_t>& entities,
+                     const std::span<const std::int32_t>& entities,
                      bool orient);
 
 /// @brief Compute the indices of all exterior facets that are owned by
@@ -180,7 +180,7 @@ CellPartitionFunction create_cell_partitioner(const graph::partition_fn& partfn
 /// incident to entities in `entities` (topological dimension `d0`)
 std::vector<std::int32_t>
 compute_incident_entities(const Mesh& mesh,
-                          const xtl::span<const std::int32_t>& entities, int d0,
+                          const std::span<const std::int32_t>& entities, int d0,
                           int d1);
 
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <numeric>
 #include <vector>
+#include <xtensor/xadapt.hpp>
 #include <xtensor/xtensor.hpp>
 
 using namespace dolfinx;
@@ -324,9 +325,9 @@ face_long_edge(const mesh::Mesh& mesh)
     const std::size_t local1 = std::distance(cell_vertices.begin(), it1);
 
     auto x_dofs = x_dofmap.links(cells.front());
-    xtl::span<const double, 3> x0(
+    std::span<const double, 3> x0(
         mesh.geometry().x().data() + 3 * x_dofs[local0], 3);
-    xtl::span<const double, 3> x1(
+    std::span<const double, 3> x1(
         mesh.geometry().x().data() + 3 * x_dofs[local1], 3);
 
     // Compute length of edge between vertex x0 and x1
@@ -450,8 +451,9 @@ compute_parent_facets(const std::vector<std::int32_t>& simplex_set)
 }
 //-----------------------------------------------------------------------------
 // Convenient interface for both uniform and marker refinement
-std::tuple<graph::AdjacencyList<std::int64_t>, xt::xtensor<double, 2>,
-           std::vector<std::int32_t>, std::vector<std::int8_t>>
+std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<double>,
+           std::array<std::size_t, 2>, std::vector<std::int32_t>,
+           std::vector<std::int8_t>>
 compute_refinement(MPI_Comm neighbor_comm,
                    const std::vector<std::int8_t>& marked_edges,
                    const graph::AdjacencyList<int>& shared_edges,
@@ -473,7 +475,7 @@ compute_refinement(MPI_Comm neighbor_comm,
          or options == plaza::RefinementOptions::parent_cell_and_facet);
 
   // Make new vertices in parallel
-  const auto [new_vertex_map, new_vertex_coordinates]
+  const auto [new_vertex_map, new_vertex_coords, xshape]
       = create_new_vertices(neighbor_comm, shared_edges, mesh, marked_edges);
 
   std::vector<std::int32_t> parent_cell;
@@ -602,7 +604,7 @@ compute_refinement(MPI_Comm neighbor_comm,
   graph::AdjacencyList<std::int64_t> cell_adj(std::move(cell_topology),
                                               std::move(offsets));
 
-  return {std::move(cell_adj), std::move(new_vertex_coordinates),
+  return {std::move(cell_adj), std::move(new_vertex_coords), xshape,
           std::move(parent_cell), std::move(parent_facet)};
 }
 //-----------------------------------------------------------------------------
@@ -614,13 +616,15 @@ plaza::refine(const mesh::Mesh& mesh, bool redistribute,
               RefinementOptions options)
 {
 
-  auto [cell_adj, new_vertex_coordinates, parent_cell, parent_facet]
+  auto [cell_adj, new_vertex_coords, xshape, parent_cell, parent_facet]
       = plaza::compute_refinement_data(mesh, options);
 
   if (dolfinx::MPI::size(mesh.comm()) == 1)
   {
+    auto coords = xt::adapt(new_vertex_coords,
+                            std::vector<std::size_t>{xshape[0], xshape[1]});
     return {mesh::create_mesh(mesh.comm(), cell_adj, mesh.geometry().cmap(),
-                              new_vertex_coordinates, mesh::GhostMode::none),
+                              coords, mesh::GhostMode::none),
             std::move(parent_cell), std::move(parent_facet)};
   }
 
@@ -638,24 +642,27 @@ plaza::refine(const mesh::Mesh& mesh, bool redistribute,
                                          ? mesh::GhostMode::none
                                          : mesh::GhostMode::shared_facet;
 
-  return {partition(mesh, cell_adj, new_vertex_coordinates, redistribute,
-                    ghost_mode),
+  auto coords = xt::adapt(new_vertex_coords,
+                          std::vector<std::size_t>{xshape[0], xshape[1]});
+  return {partition(mesh, cell_adj, coords, redistribute, ghost_mode),
           std::move(parent_cell), std::move(parent_facet)};
 }
 //-----------------------------------------------------------------------------
 std::tuple<mesh::Mesh, std::vector<std::int32_t>, std::vector<std::int8_t>>
 plaza::refine(const mesh::Mesh& mesh,
-              const xtl::span<const std::int32_t>& edges, bool redistribute,
+              const std::span<const std::int32_t>& edges, bool redistribute,
               RefinementOptions options)
 {
 
-  auto [cell_adj, new_vertex_coordinates, parent_cell, parent_facet]
+  auto [cell_adj, new_vertex_coords, xshape, parent_cell, parent_facet]
       = plaza::compute_refinement_data(mesh, edges, options);
 
   if (dolfinx::MPI::size(mesh.comm()) == 1)
   {
+    auto coords = xt::adapt(new_vertex_coords,
+                            std::vector<std::size_t>{xshape[0], xshape[1]});
     return {mesh::create_mesh(mesh.comm(), cell_adj, mesh.geometry().cmap(),
-                              new_vertex_coordinates, mesh::GhostMode::none),
+                              coords, mesh::GhostMode::none),
             std::move(parent_cell), std::move(parent_facet)};
   }
 
@@ -673,13 +680,15 @@ plaza::refine(const mesh::Mesh& mesh,
                                          ? mesh::GhostMode::none
                                          : mesh::GhostMode::shared_facet;
 
-  return {partition(mesh, cell_adj, new_vertex_coordinates, redistribute,
-                    ghost_mode),
+  auto coords = xt::adapt(new_vertex_coords,
+                          std::vector<std::size_t>{xshape[0], xshape[1]});
+  return {partition(mesh, cell_adj, coords, redistribute, ghost_mode),
           std::move(parent_cell), std::move(parent_facet)};
 }
 //------------------------------------------------------------------------------
-std::tuple<graph::AdjacencyList<std::int64_t>, xt::xtensor<double, 2>,
-           std::vector<std::int32_t>, std::vector<std::int8_t>>
+std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<double>,
+           std::array<std::size_t, 2>, std::vector<std::int32_t>,
+           std::vector<std::int8_t>>
 plaza::compute_refinement_data(const mesh::Mesh& mesh,
                                RefinementOptions options)
 {
@@ -721,21 +730,22 @@ plaza::compute_refinement_data(const mesh::Mesh& mesh,
                                  MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm);
 
   const auto [long_edge, edge_ratio_ok] = face_long_edge(mesh);
-  auto [cell_adj, new_vertex_coordinates, parent_cell, parent_facet]
+  auto [cell_adj, new_vertex_coords, xshape, parent_cell, parent_facet]
       = compute_refinement(comm,
                            std::vector<std::int8_t>(
                                map_e->size_local() + map_e->num_ghosts(), true),
                            edge_ranks, mesh, long_edge, edge_ratio_ok, options);
   MPI_Comm_free(&comm);
 
-  return {std::move(cell_adj), std::move(new_vertex_coordinates),
+  return {std::move(cell_adj), std::move(new_vertex_coords), xshape,
           std::move(parent_cell), std::move(parent_facet)};
 }
 //------------------------------------------------------------------------------
-std::tuple<graph::AdjacencyList<std::int64_t>, xt::xtensor<double, 2>,
-           std::vector<std::int32_t>, std::vector<std::int8_t>>
+std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<double>,
+           std::array<std::size_t, 2>, std::vector<std::int32_t>,
+           std::vector<std::int8_t>>
 plaza::compute_refinement_data(const mesh::Mesh& mesh,
-                               const xtl::span<const std::int32_t>& edges,
+                               const std::span<const std::int32_t>& edges,
                                RefinementOptions options)
 {
   if (mesh.topology().cell_type() != mesh::CellType::triangle
@@ -798,12 +808,12 @@ plaza::compute_refinement_data(const mesh::Mesh& mesh,
   const auto [long_edge, edge_ratio_ok] = face_long_edge(mesh);
   enforce_rules(comm, edge_ranks, marked_edges, mesh, long_edge);
 
-  auto [cell_adj, new_vertex_coordinates, parent_cell, parent_facet]
+  auto [cell_adj, new_vertex_coords, xshape, parent_cell, parent_facet]
       = compute_refinement(comm, marked_edges, edge_ranks, mesh, long_edge,
                            edge_ratio_ok, options);
   MPI_Comm_free(&comm);
 
-  return {std::move(cell_adj), std::move(new_vertex_coordinates),
+  return {std::move(cell_adj), std::move(new_vertex_coords), xshape,
           std::move(parent_cell), std::move(parent_facet)};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -6,9 +6,10 @@
 
 #include <cstdint>
 #include <dolfinx/graph/AdjacencyList.h>
+#include <span>
+#include <tuple>
 #include <utility>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 #pragma once
 
@@ -67,7 +68,7 @@ refine(const mesh::Mesh& mesh, bool redistribute, RefinementOptions options);
 /// returned.
 /// @return New Mesh and optional parent cell index, parent facet indices
 std::tuple<mesh::Mesh, std::vector<std::int32_t>, std::vector<std::int8_t>>
-refine(const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& edges,
+refine(const mesh::Mesh& mesh, const std::span<const std::int32_t>& edges,
        bool redistribute, RefinementOptions options);
 
 /// Refine mesh returning new mesh data.
@@ -76,10 +77,12 @@ refine(const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& edges,
 /// @param[in] options RefinementOptions enum to choose the computation of
 /// parent facets, parent cells. If an option is unselected, an empty list is
 /// returned.
-/// @return New mesh data: cell topology, vertex coordinates, and optional
-/// parent cell index, and parent facet indices.
-std::tuple<graph::AdjacencyList<std::int64_t>, xt::xtensor<double, 2>,
-           std::vector<std::int32_t>, std::vector<std::int8_t>>
+/// @return New mesh data: cell topology, vertex coordinates, vertex
+/// coordinates shape,  and optional parent cell index, and parent facet
+/// indices.
+std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<double>,
+           std::array<std::size_t, 2>, std::vector<std::int32_t>,
+           std::vector<std::int8_t>>
 compute_refinement_data(const mesh::Mesh& mesh, RefinementOptions options);
 
 /// Refine with markers returning new mesh data.
@@ -92,10 +95,11 @@ compute_refinement_data(const mesh::Mesh& mesh, RefinementOptions options);
 /// returned.
 /// @return New mesh data: cell topology, vertex coordinates and parent
 /// cell index, and stored parent facet indices (if requested).
-std::tuple<graph::AdjacencyList<std::int64_t>, xt::xtensor<double, 2>,
-           std::vector<std::int32_t>, std::vector<std::int8_t>>
+std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<double>,
+           std::array<std::size_t, 2>, std::vector<std::int32_t>,
+           std::vector<std::int8_t>>
 compute_refinement_data(const mesh::Mesh& mesh,
-                        const xtl::span<const std::int32_t>& edges,
+                        const std::span<const std::int32_t>& edges,
                         RefinementOptions options);
 
 } // namespace plaza

--- a/cpp/dolfinx/refinement/refine.cpp
+++ b/cpp/dolfinx/refinement/refine.cpp
@@ -36,7 +36,7 @@ mesh::Mesh refinement::refine(const mesh::Mesh& mesh, bool redistribute)
 }
 //-----------------------------------------------------------------------------
 mesh::Mesh refinement::refine(const mesh::Mesh& mesh,
-                              const xtl::span<const std::int32_t>& edges,
+                              const std::span<const std::int32_t>& edges,
                               bool redistribute)
 {
   if (mesh.topology().cell_type() != mesh::CellType::triangle

--- a/cpp/dolfinx/refinement/refine.h
+++ b/cpp/dolfinx/refinement/refine.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <vector>
-#include <xtl/xspan.hpp>
 
 namespace dolfinx::mesh
 {
@@ -37,7 +37,7 @@ mesh::Mesh refine(const mesh::Mesh& mesh, bool redistribute = true);
 /// refined mesh if mesh is a distributed mesh.
 /// @return A locally refined mesh
 mesh::Mesh refine(const mesh::Mesh& mesh,
-                  const xtl::span<const std::int32_t>& edges,
+                  const std::span<const std::int32_t>& edges,
                   bool redistribute = true);
 
 } // namespace dolfinx::refinement

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -55,7 +55,7 @@ std::int64_t local_to_global(std::int32_t local_index,
 /// @param Mesh
 /// @param local_edge_to_new_vertex
 /// @return array of points
-xt::xtensor<double, 2> create_new_geometry(
+std::pair<std::vector<double>, std::array<std::size_t, 2>> create_new_geometry(
     const mesh::Mesh& mesh,
     const std::map<std::int32_t, std::int64_t>& local_edge_to_new_vertex)
 {
@@ -85,18 +85,18 @@ xt::xtensor<double, 2> create_new_geometry(
   }
 
   // Copy over existing mesh vertices
-  xtl::span<const double> x_g = mesh.geometry().x();
-
+  std::span<const double> x_g = mesh.geometry().x();
+  const std::size_t gdim = mesh.geometry().dim();
   const std::size_t num_vertices = map_v->size_local();
   const std::size_t num_new_vertices = local_edge_to_new_vertex.size();
-  xt::xtensor<double, 2> new_vertex_coordinates(
-      {num_vertices + num_new_vertices, 3});
 
+  std::array<std::size_t, 2> shape = {num_vertices + num_new_vertices, gdim};
+  std::vector<double> new_vertex_coords(shape[0] * shape[1]);
   for (std::size_t v = 0; v < num_vertices; ++v)
   {
-    const int pos = 3 * vertex_to_x[v];
-    for (std::size_t j = 0; j < 3; ++j)
-      new_vertex_coordinates(v, j) = x_g[pos + j];
+    std::size_t pos = 3 * vertex_to_x[v];
+    for (std::size_t j = 0; j < gdim; ++j)
+      new_vertex_coords[gdim * v + j] = x_g[pos + j];
   }
 
   // Compute new vertices
@@ -107,23 +107,15 @@ xt::xtensor<double, 2> create_new_geometry(
     for (auto& e : local_edge_to_new_vertex)
       edges[i++] = e.first;
 
+    // Compute midpoint of each edge (padded to 3D)
     const std::vector<double> midpoints
         = mesh::compute_midpoints(mesh, 1, edges);
-
-    std::vector<std::size_t> shape = {edges.size(), 3};
-    auto _midpoints = xt::adapt(midpoints, shape);
-
-    // The below should work, but misbehaves with the Intel icpx compiler
-    // xt::view(new_vertex_coordinates, xt::range(-num_new_vertices, _),
-    // xt::all())
-    //     = midpoints;
-    auto _vertex = xt::view(new_vertex_coordinates,
-                            xt::range(-num_new_vertices, _), xt::all());
-    _vertex.assign(_midpoints);
+    for (std::size_t i = 0; i < num_new_vertices; ++i)
+      for (std::size_t j = 0; j < gdim; ++j)
+        new_vertex_coords[gdim * (num_vertices + i) + j] = midpoints[3 * i + j];
   }
 
-  return xt::view(new_vertex_coordinates, xt::all(),
-                  xt::range(0, mesh.geometry().dim()));
+  return {std::move(new_vertex_coords), shape};
 }
 } // namespace
 
@@ -184,7 +176,8 @@ void refinement::update_logical_edgefunction(
   }
 }
 //-----------------------------------------------------------------------------
-std::pair<std::map<std::int32_t, std::int64_t>, xt::xtensor<double, 2>>
+std::tuple<std::map<std::int32_t, std::int64_t>, std::vector<double>,
+           std::array<std::size_t, 2>>
 refinement::create_new_vertices(MPI_Comm neighbor_comm,
                                 const graph::AdjacencyList<int>& shared_edges,
                                 const mesh::Mesh& mesh,
@@ -216,7 +209,7 @@ refinement::create_new_vertices(MPI_Comm neighbor_comm,
                 [global_offset](auto& e) { e.second += global_offset; });
 
   // Create actual points
-  xt::xtensor<double, 2> new_vertex_coordinates
+  auto [new_vertex_coords, xshape]
       = create_new_geometry(mesh, local_edge_to_new_vertex);
 
   // If they are shared, then the new global vertex index needs to be
@@ -299,8 +292,8 @@ refinement::create_new_vertices(MPI_Comm neighbor_comm,
     assert(it.second);
   }
 
-  return {std::move(local_edge_to_new_vertex),
-          std::move(new_vertex_coordinates)};
+  return {std::move(local_edge_to_new_vertex), std::move(new_vertex_coords),
+          xshape};
 }
 //-----------------------------------------------------------------------------
 mesh::Mesh

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -20,11 +20,8 @@
 #include <memory>
 #include <mpi.h>
 #include <vector>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
-using namespace xt::placeholders;
 
 namespace
 {
@@ -299,14 +296,15 @@ refinement::create_new_vertices(MPI_Comm neighbor_comm,
 mesh::Mesh
 refinement::partition(const mesh::Mesh& old_mesh,
                       const graph::AdjacencyList<std::int64_t>& cell_topology,
-                      const xt::xtensor<double, 2>& new_vertex_coordinates,
-                      bool redistribute, mesh::GhostMode gm)
+                      std::span<const double> new_coords,
+                      std::array<std::size_t, 2> xshape, bool redistribute,
+                      mesh::GhostMode gm)
 {
   if (redistribute)
   {
-    xt::xtensor<double, 2> new_coords(new_vertex_coordinates);
     return mesh::create_mesh(old_mesh.comm(), cell_topology,
-                             old_mesh.geometry().cmap(), new_coords, gm);
+                             old_mesh.geometry().cmap(), new_coords, xshape,
+                             gm);
   }
 
   auto partitioner = [](MPI_Comm comm, int, int tdim,
@@ -368,8 +366,8 @@ refinement::partition(const mesh::Mesh& old_mesh,
   };
 
   return mesh::create_mesh(old_mesh.comm(), cell_topology,
-                           old_mesh.geometry().cmap(), new_vertex_coordinates,
-                           gm, partitioner);
+                           old_mesh.geometry().cmap(), new_coords, xshape, gm,
+                           partitioner);
 }
 //-----------------------------------------------------------------------------
 

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -6,13 +6,16 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <map>
 #include <memory>
 #include <set>
+#include <tuple>
 #include <vector>
+#include <xtensor/xtensor.hpp>
 
 namespace dolfinx::mesh
 {
@@ -54,8 +57,10 @@ void update_logical_edgefunction(
 /// @param[in] mesh Existing mesh
 /// @param[in] marked_edges
 /// @return (0) map from local edge index to new vertex global index,
-/// and (1) the coordinates of the new vertices
-std::pair<std::map<std::int32_t, std::int64_t>, xt::xtensor<double, 2>>
+/// (1) the coordinates of the new vertices (row-major storage) and (2)
+/// the shape of the new coordinates.
+std::tuple<std::map<std::int32_t, std::int64_t>, std::vector<double>,
+           std::array<std::size_t, 2>>
 create_new_vertices(MPI_Comm neighbor_comm,
                     const graph::AdjacencyList<int>& shared_edges,
                     const mesh::Mesh& mesh,

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -15,7 +15,6 @@
 #include <set>
 #include <tuple>
 #include <vector>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx::mesh
 {
@@ -70,14 +69,16 @@ create_new_vertices(MPI_Comm neighbor_comm,
 /// processes
 /// @param[in] old_mesh
 /// @param[in] cell_topology Topology of cells, (vertex indices)
-/// @param[in] new_vertex_coordinates
+/// @param[in] new_coords New coordinates, row-major storage
+/// @param[in] xshape The shape of `new_coords`
 /// @param[in] redistribute Call graph partitioner if true
 /// @param[in] ghost_mode None or shared_facet
 /// @return New mesh
 mesh::Mesh partition(const mesh::Mesh& old_mesh,
                      const graph::AdjacencyList<std::int64_t>& cell_topology,
-                     const xt::xtensor<double, 2>& new_vertex_coordinates,
-                     bool redistribute, mesh::GhostMode ghost_mode);
+                     std::span<const double> new_coords,
+                     std::array<std::size_t, 2> xshape, bool redistribute,
+                     mesh::GhostMode ghost_mode);
 
 /// @todo Fix docstring. It is unclear.
 ///

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(dolfinx-tests)
 
 project(${PROJECT_NAME} LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -41,8 +41,8 @@ void test_scatter_fwd(int n)
   std::vector<std::int64_t> data_ghost(n * num_ghosts, -1);
 
   // Scatter values to ghost and check value is correctly received
-  sct.scatter_fwd<std::int64_t>(xtl::span<const std::int64_t>(data_local),
-                                xtl::span<std::int64_t>(data_ghost));
+  sct.scatter_fwd<std::int64_t>(std::span<const std::int64_t>(data_local),
+                                std::span<std::int64_t>(data_ghost));
   CHECK((int)data_ghost.size() == n * num_ghosts);
   CHECK(std::all_of(data_ghost.begin(), data_ghost.end(),
                     [=](auto i)
@@ -75,8 +75,8 @@ void test_scatter_rev()
   std::int64_t value = 15;
   std::vector<std::int64_t> data_local(n * size_local, 0);
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
-  sct.scatter_rev(xtl::span<std::int64_t>(data_local),
-                  xtl::span<const std::int64_t>(data_ghost),
+  sct.scatter_rev(std::span<std::int64_t>(data_local),
+                  std::span<const std::int64_t>(data_ghost),
                   std::plus<std::int64_t>());
 
   std::int64_t sum;
@@ -84,15 +84,15 @@ void test_scatter_rev()
   sum = std::reduce(data_local.begin(), data_local.end(), 0);
   CHECK(sum == n * value * num_ghosts);
 
-  sct.scatter_rev(xtl::span<std::int64_t>(data_local),
-                  xtl::span<const std::int64_t>(data_ghost),
+  sct.scatter_rev(std::span<std::int64_t>(data_local),
+                  std::span<const std::int64_t>(data_ghost),
                   [](auto /*a*/, auto b) { return b; });
 
   sum = std::reduce(data_local.begin(), data_local.end(), 0);
   CHECK(sum == n * value * num_ghosts);
 
-  sct.scatter_rev(xtl::span<std::int64_t>(data_local),
-                  xtl::span<const std::int64_t>(data_ghost),
+  sct.scatter_rev(std::span<std::int64_t>(data_local),
+                  std::span<const std::int64_t>(data_ghost),
                   std::plus<std::int64_t>());
   sum = std::reduce(data_local.begin(), data_local.end(), 0);
   CHECK(sum == 2 * n * value * num_ghosts);

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -6,8 +6,6 @@
 
 #include <catch2/catch.hpp>
 #include <dolfinx/common/sort.h>
-#include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
 
 TEMPLATE_TEST_CASE("Test radix sort", "[vector][template]", std::int32_t,
                    std::int64_t)

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -23,7 +23,7 @@ TEMPLATE_TEST_CASE("Test radix sort", "[vector][template]", std::int32_t,
   std::generate_n(std::back_inserter(vec), vec_size, generator);
 
   // Sort vector using radix sort
-  dolfinx::radix_sort(xtl::span(vec));
+  dolfinx::radix_sort(std::span(vec));
 
   // Check if vector is sorted
   REQUIRE(std::is_sorted(vec.begin(), vec.end()));
@@ -61,6 +61,9 @@ TEST_CASE("Test argsort bitset")
   // Requiring equality of permutation vectors is not a good test, because
   // std::sort is not stable, so we compare the effect on the actual array.
   for (std::size_t i = 0; i < perm.size(); i++)
-    REQUIRE((xtl::span(arr.data() + shape1 * perm[i], shape1)
-             == xtl::span(arr.data() + shape1 * index[i], shape1)));
+  {
+    REQUIRE(std::equal(arr.data() + shape1 * perm[i],
+                       arr.data() + shape1 * perm[i] + shape1,
+                       arr.data() + shape1 * index[i]));
+  }
 }

--- a/cpp/test/io.cpp
+++ b/cpp/test/io.cpp
@@ -6,13 +6,12 @@
 
 #ifdef HAS_ADIOS2
 
+#include <algorithm>
 #include <catch2/catch.hpp>
 #include <dolfinx/io/ADIOS2Writers.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/generation.h>
 #include <mpi.h>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 
@@ -26,17 +25,17 @@ void test_fides_mesh()
       mesh::CellType::triangle, mesh::GhostMode::shared_facet));
   io::FidesWriter writer(mesh->comm(), "test_mesh.bp", mesh);
   writer.write(0.0);
-  auto points
-      = xt::adapt(mesh->geometry().x().data(), mesh->geometry().x().size(),
-                  xt::no_ownership(),
-                  std::vector{mesh->geometry().x().size() / 3, std::size_t(3)});
+
+  auto x = mesh->geometry().x();
+
   // Move all coordinates of the mesh geometry
-  points += 1;
+  std::transform(x.begin(), x.end(), x.begin(), [](auto x) { return x + 1; });
   writer.write(0.2);
 
   // Only move x coordinate
-  auto x_coords = xt::view(points, xt::all(), 0);
-  x_coords -= 0.5;
+  for (std::size_t i = 0; i < x.size(); i += 3)
+    x[i] -= 0.5;
+
   writer.write(0.4);
 }
 

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -29,11 +29,11 @@ namespace
 /// @param[in] x Input vector
 /// @param[in, out] x Output vector
 template <typename T>
-void spmv_impl(xtl::span<const T> values,
-               xtl::span<const std::int32_t> row_begin,
-               xtl::span<const std::int32_t> row_end,
-               xtl::span<const std::int32_t> indices, xtl::span<const T> x,
-               xtl::span<T> y)
+void spmv_impl(std::span<const T> values,
+               std::span<const std::int32_t> row_begin,
+               std::span<const std::int32_t> row_end,
+               std::span<const std::int32_t> indices, std::span<const T> x,
+               std::span<T> y)
 {
   assert(row_begin.size() == row_end.size());
   for (std::size_t i = 0; i < row_begin.size(); i++)
@@ -78,17 +78,17 @@ void spmv(la::MatrixCSR<T>& A, la::Vector<T>& x, la::Vector<T>& y)
   x.scatter_fwd_begin();
 
   const std::int32_t nrowslocal = A.num_owned_rows();
-  xtl::span<const std::int32_t> row_ptr(A.row_ptr().data(), nrowslocal + 1);
-  xtl::span<const std::int32_t> cols(A.cols().data(), row_ptr[nrowslocal]);
-  xtl::span<const std::int32_t> off_diag_offset(A.off_diag_offset().data(),
+  std::span<const std::int32_t> row_ptr(A.row_ptr().data(), nrowslocal + 1);
+  std::span<const std::int32_t> cols(A.cols().data(), row_ptr[nrowslocal]);
+  std::span<const std::int32_t> off_diag_offset(A.off_diag_offset().data(),
                                                 nrowslocal);
-  xtl::span<const T> values(A.values().data(), row_ptr[nrowslocal]);
+  std::span<const T> values(A.values().data(), row_ptr[nrowslocal]);
 
-  xtl::span<const T> _x = x.array();
-  xtl::span<T> _y = y.mutable_array();
+  std::span<const T> _x = x.array();
+  std::span<T> _y = y.mutable_array();
 
-  xtl::span<const std::int32_t> row_begin(row_ptr.data(), nrowslocal);
-  xtl::span<const std::int32_t> row_end(row_ptr.data() + 1, nrowslocal);
+  std::span<const std::int32_t> row_begin(row_ptr.data(), nrowslocal);
+  std::span<const std::int32_t> row_end(row_ptr.data() + 1, nrowslocal);
 
   // First stage:  spmv - diagonal
   // yi[0] += Ai[0] * xi[0]

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -70,24 +70,26 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
     io::XDMFFile infile(subset_comm, "mesh.xdmf", "r");
     cells = infile.read_topology_data("mesh");
     x = infile.read_geometry_data("mesh");
-    auto [data, offsets] = graph::create_adjacency_data(cells);
 
     int nparts = mpi_size;
     const int tdim = mesh::cell_dim(mesh::CellType::triangle);
     dest = partitioner(
         subset_comm, nparts, tdim,
-        graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offsets)),
+        graph::regular_adjacency_list(
+            std::vector(cells.data(), cells.data() + cells.size()),
+            cells.shape(1)),
         mesh::GhostMode::shared_facet);
   }
   CHECK(x.shape(1) == 2);
 
-  auto [data, offsets] = graph::create_adjacency_data(cells);
-  graph::AdjacencyList<std::int64_t> cells_topology(std::move(data),
-                                                    std::move(offsets));
-
   // Distribute cells to destination ranks
   const auto [cell_nodes, src, original_cell_index, ghost_owners]
-      = graph::build::distribute(mpi_comm, cells_topology, dest);
+      = graph::build::distribute(
+          mpi_comm,
+          graph::regular_adjacency_list(
+              std::vector(cells.data(), cells.data() + cells.size()),
+              cells.shape(1)),
+          dest);
 
   mesh::Topology topology = mesh::create_topology(
       mpi_comm, cell_nodes, original_cell_index, ghost_owners,

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -60,36 +60,29 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
   fem::CoordinateElement cmap(e);
 
   // read mesh data
-  xt::xtensor<double, 2> x({0, 2});
-  xt::xtensor<std::int64_t, 2> cells(
-      {0, static_cast<std::size_t>(
-              mesh::num_cell_vertices(mesh::CellType::triangle))});
+  std::vector<double> x;
+  std::array<std::size_t, 2> xshape = {0, 2};
+  std::vector<std::int64_t> cells;
+  std::array<std::size_t, 2> cshape = {0, 3};
   graph::AdjacencyList<std::int32_t> dest(0);
   if (subset_comm != MPI_COMM_NULL)
   {
     io::XDMFFile infile(subset_comm, "mesh.xdmf", "r");
-    cells = infile.read_topology_data("mesh");
-    x = infile.read_geometry_data("mesh");
+    std::tie(cells, cshape) = infile.read_topology_data("mesh");
+    std::tie(x, xshape) = infile.read_geometry_data("mesh");
 
     int nparts = mpi_size;
     const int tdim = mesh::cell_dim(mesh::CellType::triangle);
-    dest = partitioner(
-        subset_comm, nparts, tdim,
-        graph::regular_adjacency_list(
-            std::vector(cells.data(), cells.data() + cells.size()),
-            cells.shape(1)),
-        mesh::GhostMode::shared_facet);
+    dest = partitioner(subset_comm, nparts, tdim,
+                       graph::regular_adjacency_list(cells, cshape[1]),
+                       mesh::GhostMode::shared_facet);
   }
-  CHECK(x.shape(1) == 2);
+  CHECK(xshape[1] == 2);
 
   // Distribute cells to destination ranks
   const auto [cell_nodes, src, original_cell_index, ghost_owners]
       = graph::build::distribute(
-          mpi_comm,
-          graph::regular_adjacency_list(
-              std::vector(cells.data(), cells.data() + cells.size()),
-              cells.shape(1)),
-          dest);
+          mpi_comm, graph::regular_adjacency_list(cells, cshape[1]), dest);
 
   mesh::Topology topology = mesh::create_topology(
       mpi_comm, cell_nodes, original_cell_index, ghost_owners,
@@ -97,7 +90,7 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
   int tdim = topology.dim();
 
   mesh::Geometry geometry = mesh::create_geometry(mpi_comm, topology, cmap,
-                                                  cell_nodes, x, x.shape(1));
+                                                  cell_nodes, x, xshape[1]);
 
   auto mesh = std::make_shared<mesh::Mesh>(mpi_comm, std::move(topology),
                                            std::move(geometry));

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -10,7 +10,6 @@
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/la/Vector.h>
-#include <xtensor/xtensor.hpp>
 
 using namespace dolfinx;
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16)
 
 PROJECT(dolfinx_pybind11)
 
+# Set C++ standard before finding pybind11
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Development component which includes both Development.Module and
 # Development.Embed is not required for building a Python module.  Correct
 # COMPONENT specification Development.Module added only in CMake 3.18 and
@@ -35,11 +40,6 @@ get_target_property(DOLFINX_DEFN dolfinx INTERFACE_COMPILE_DEFINITIONS)
 if("XTENSOR_USE_XSIMD" IN_LIST BASIX_DEFN OR "XTENSOR_USE_XSIMD" IN_LIST DOLFINX_DEFN)
   find_package(xsimd REQUIRED)
 endif()
-
-# Set C++ standard before finding pybind11
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Create the binding library
 # pybind11 handles its own calls to target_link_libraries

--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -222,7 +222,7 @@ sigma_vm = ufl.sqrt((3 / 2) * inner(sigma_dev, sigma_dev))
 
 # +
 W = FunctionSpace(msh, ("Discontinuous Lagrange", 0))
-sigma_vm_expr = Expression(sigma_vm, W.element.interpolation_points)
+sigma_vm_expr = Expression(sigma_vm, W.element.interpolation_points())
 sigma_vm_h = Function(W)
 sigma_vm_h.interpolate(sigma_vm_expr)
 # -

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -65,7 +65,7 @@ C++ core
 
 .. rubric:: Required
 
-- C++ compiler (supporting the C++17 standard)
+- C++ compiler (supporting the C++20 standard)
 - `Boost <http://www.boost.org>`_, with the following compiled Boost
   components
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -159,7 +159,7 @@ class Expression:
             argument_space_dimension = 1
         else:
             argument_space_dimension = self.argument_function_space.element.space_dimension
-        values_shape = (_cells.shape[0], self.X.shape[0] * self.value_size * argument_space_dimension)
+        values_shape = (_cells.shape[0], self.X().shape[0] * self.value_size * argument_space_dimension)
 
         # Allocate memory for result if u was not provided
         if values is None:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -174,15 +174,14 @@ class Expression:
 
         return values
 
+    def X(self) -> np.ndarray:
+        """Evaluation points on the reference cell"""
+        return self._cpp_object.X()
+
     @property
     def ufl_expression(self):
         """Original UFL Expression"""
         return self._ufl_expression
-
-    @property
-    def X(self) -> np.ndarray:
-        """Evaluation points on the reference cell"""
-        return self._cpp_object.X
 
     @property
     def value_size(self) -> int:

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -309,8 +309,8 @@ void declare_objects(py::module& m, const std::string& type)
                 std::transform(g.strides(), g.strides() + g.ndim(),
                                std::back_inserter(strides),
                                [](auto s) { return s / sizeof(T); });
-                std::vector<std::size_t> shape(g.shape(), g.shape() +
-                g.ndim()); auto _g = xt::adapt(g.data(), g.size(),
+                std::vector<std::size_t> shape(g.shape(), g.shape() + g.ndim());
+                auto _g = xt::adapt(g.data(), g.size(),
                 xt::no_ownership(),
                                     shape, strides);
                 return dolfinx::fem::DirichletBC<T>(

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -43,12 +43,13 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
+#include <span>
 #include <string>
 #include <ufcx.h>
 #include <utility>
 #include <xtensor/xadapt.hpp>
+#include <xtensor/xbuilder.hpp>
 #include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
 
 namespace py = pybind11;
 
@@ -67,15 +68,18 @@ struct geom_type<T, std::void_t<typename T::value_type>>
 
 template <typename T>
 std::map<std::pair<dolfinx::fem::IntegralType, int>,
-         std::pair<xtl::span<const T>, int>>
+         std::pair<std::span<const T>, int>>
 py_to_cpp_coeffs(const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                                 py::array_t<T, py::array::c_style>>& coeffs)
 {
   using Key_t = typename std::remove_reference_t<decltype(coeffs)>::key_type;
-  std::map<Key_t, std::pair<xtl::span<const T>, int>> c;
-  std::transform(coeffs.cbegin(), coeffs.cend(), std::inserter(c, c.end()),
-                 [](auto& e) -> typename decltype(c)::value_type {
-                   return {e.first, {e.second, e.second.shape(1)}};
+  std::map<Key_t, std::pair<std::span<const T>, int>> c;
+  std::transform(coeffs.begin(), coeffs.end(), std::inserter(c, c.end()),
+                 [](auto& e) -> typename decltype(c)::value_type
+                 {
+                   return {e.first,
+                           {std::span(e.second.data(), e.second.size()),
+                            e.second.shape(1)}};
                  });
   return c;
 }
@@ -133,8 +137,9 @@ void declare_functions(py::module& m)
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         py::array_t<T, py::array::c_style>>& coefficients)
       {
-        return dolfinx::fem::assemble_scalar<T>(M, constants,
-                                                py_to_cpp_coeffs(coefficients));
+        return dolfinx::fem::assemble_scalar<T>(
+            M, std::span(constants.data(), constants.size()),
+            py_to_cpp_coeffs(coefficients));
       },
       py::arg("M"), py::arg("constants"), py::arg("coefficients"),
       "Assemble functional over mesh with provided constants and "
@@ -147,9 +152,10 @@ void declare_functions(py::module& m)
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         py::array_t<T, py::array::c_style>>& coefficients)
       {
-        dolfinx::fem::assemble_vector<T>(xtl::span(b.mutable_data(), b.size()),
-                                         L, constants,
-                                         py_to_cpp_coeffs(coefficients));
+        dolfinx::fem::assemble_vector<T>(
+            std::span(b.mutable_data(), b.size()), L,
+            std::span(constants.data(), constants.size()),
+            py_to_cpp_coeffs(coefficients));
       },
       py::arg("b"), py::arg("L"), py::arg("constants"), py::arg("coeffs"),
       "Assemble linear form into an existing vector with pre-packed constants "
@@ -170,9 +176,10 @@ void declare_functions(py::module& m)
           throw std::runtime_error("Assembly with block size > 1 not yet "
                                    "supported with la::MatrixCSR.");
         }
-        dolfinx::fem::assemble_matrix(A.mat_add_values(), a,
-                                      xtl::span(constants),
-                                      py_to_cpp_coeffs(coefficients), bcs);
+        dolfinx::fem::assemble_matrix(
+            A.mat_add_values(), a,
+            std::span(constants.data(), constants.size()),
+            py_to_cpp_coeffs(coefficients), bcs);
       },
       py::arg("A"), py::arg("a"), py::arg("constants"), py::arg("coeffs"),
       py::arg("bcs"), "Experimental.");
@@ -194,9 +201,9 @@ void declare_functions(py::module& m)
          const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<T>>>&
              bcs)
       {
-        auto f = [&fin](const xtl::span<const std::int32_t>& rows,
-                        const xtl::span<const std::int32_t>& cols,
-                        const xtl::span<const T>& data)
+        auto f = [&fin](const std::span<const std::int32_t>& rows,
+                        const std::span<const std::int32_t>& cols,
+                        const std::span<const T>& data)
         {
           return fin(py::array(rows.size(), rows.data()),
                      py::array(cols.size(), cols.data()),
@@ -222,23 +229,23 @@ void declare_functions(py::module& m)
          const std::vector<py::array_t<T, py::array::c_style>>& x0,
          double scale)
       {
-        std::vector<xtl::span<const T>> _x0;
+        std::vector<std::span<const T>> _x0;
         for (const auto& x : x0)
           _x0.emplace_back(x.data(), x.size());
 
-        std::vector<xtl::span<const T>> _constants;
-        std::transform(constants.cbegin(), constants.cend(),
+        std::vector<std::span<const T>> _constants;
+        std::transform(constants.begin(), constants.end(),
                        std::back_inserter(_constants),
-                       [](auto& c) { return c; });
+                       [](auto& c) { return std::span(c.data(), c.size()); });
 
         std::vector<std::map<std::pair<dolfinx::fem::IntegralType, int>,
-                             std::pair<xtl::span<const T>, int>>>
+                             std::pair<std::span<const T>, int>>>
             _coeffs;
-        std::transform(coeffs.cbegin(), coeffs.cend(),
+        std::transform(coeffs.begin(), coeffs.end(),
                        std::back_inserter(_coeffs),
                        [](auto& c) { return py_to_cpp_coeffs(c); });
 
-        dolfinx::fem::apply_lifting<T>(xtl::span(b.mutable_data(), b.size()), a,
+        dolfinx::fem::apply_lifting<T>(std::span(b.mutable_data(), b.size()), a,
                                        _constants, _coeffs, bcs1, _x0, scale);
       },
       py::arg("b"), py::arg("a"), py::arg("constants"), py::arg("coeffs"),
@@ -253,13 +260,13 @@ void declare_functions(py::module& m)
       {
         if (x0.ndim() == 0)
         {
-          dolfinx::fem::set_bc<T>(xtl::span(b.mutable_data(), b.size()), bcs,
+          dolfinx::fem::set_bc<T>(std::span(b.mutable_data(), b.size()), bcs,
                                   scale);
         }
         else if (x0.ndim() == 1)
         {
-          dolfinx::fem::set_bc<T>(xtl::span(b.mutable_data(), b.size()), bcs,
-                                  xtl::span(x0.data(), x0.shape(0)), scale);
+          dolfinx::fem::set_bc<T>(std::span(b.mutable_data(), b.size()), bcs,
+                                  std::span(x0.data(), x0.shape(0)), scale);
         }
         else
           throw std::runtime_error("Wrong array dimension.");
@@ -393,14 +400,14 @@ void declare_objects(py::module& m, const std::string& type)
               std::copy_n(v.shape(), v.ndim(), std::back_inserter(shape));
               return xt::adapt(v.data(), shape);
             };
-            self.interpolate(_f, cells);
+            self.interpolate(_f, std::span(cells.data(), cells.size()));
           },
           py::arg("f"), py::arg("cells"), "Interpolate an expression function")
       .def(
           "interpolate",
           [](dolfinx::fem::Function<T>& self, dolfinx::fem::Function<T>& u,
              const py::array_t<std::int32_t, py::array::c_style>& cells)
-          { self.interpolate(u, cells); },
+          { self.interpolate(u, std::span(cells.data(), cells.size())); },
           py::arg("u"), py::arg("cells"),
           "Interpolate a finite element function")
       .def(
@@ -426,7 +433,7 @@ void declare_objects(py::module& m, const std::string& type)
               return values;
             };
 
-            self.interpolate(_f, cells);
+            self.interpolate(_f, std::span(cells.data(), cells.size()));
           },
           py::arg("f"), py::arg("cells"),
           "Interpolate using a pointer to an Expression with a C signature")
@@ -435,7 +442,7 @@ void declare_objects(py::module& m, const std::string& type)
           [](dolfinx::fem::Function<T>& self,
              const dolfinx::fem::Expression<T>& expr,
              const py::array_t<std::int32_t, py::array::c_style>& cells)
-          { self.interpolate(expr, cells); },
+          { self.interpolate(expr, std::span(cells.data(), cells.size())); },
           py::arg("expr"), py::arg("cells"),
           "Interpolate an Expression on a set of cells")
       .def_property_readonly(
@@ -449,23 +456,13 @@ void declare_objects(py::module& m, const std::string& type)
              py::array_t<T, py::array::c_style>& u)
           {
             // TODO: handle 1d case
-
-            std::vector<std::size_t> shape_x(x.shape(), x.shape() + 2);
-            auto _x
-                = xt::adapt(x.data(), x.size(), xt::no_ownership(), shape_x);
-
-            std::array<std::size_t, 2> shape_u;
-            std::copy_n(u.shape(), 2, shape_u.begin());
-
-            // The below should work, but misbehaves with the Intel
-            // icpx compiler
-            // xt::xtensor<T, 2> _u = xt::adapt(u.mutable_data(), u.size(),
-            //                                  xt::no_ownership(), shape_u);
-            xt::xtensor<T, 2> _u(shape_u);
-            std::copy_n(u.data(), u.size(), _u.data());
-
-            self.eval(_x, xtl::span(cells.data(), cells.size()), _u);
-            std::copy_n(_u.data(), _u.size(), u.mutable_data());
+            self.eval(std::span(x.data(), x.size()),
+                      {static_cast<std::size_t>(x.shape(0)),
+                       static_cast<std::size_t>(x.shape(1))},
+                      std::span(cells.data(), cells.size()),
+                      std::span(u.mutable_data(), u.size()),
+                      {static_cast<std::size_t>(u.shape(0)),
+                       static_cast<std::size_t>(u.shape(1))});
           },
           py::arg("x"), py::arg("cells"), py::arg("values"),
           "Evaluate Function")
@@ -503,37 +500,37 @@ void declare_objects(py::module& m, const std::string& type)
       class_<dolfinx::fem::Expression<T>,
              std::shared_ptr<dolfinx::fem::Expression<T>>>(
           m, pyclass_name_expr.c_str(), "An Expression")
-          .def(
-              py::init(
-                  [](const std::vector<std::shared_ptr<
-                         const dolfinx::fem::Function<T>>>& coefficients,
-                     const std::vector<std::shared_ptr<
-                         const dolfinx::fem::Constant<T>>>& constants,
-                     const py::array_t<double, py::array::c_style>& X,
-                     std::uintptr_t fn_addr,
-                     const std::vector<int>& value_shape,
-                     const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh,
-                     const std::shared_ptr<const dolfinx::fem::FunctionSpace>&
-                         argument_function_space)
-                  {
-                    auto tabulate_expression_ptr
-                        = (void (*)(T*, const T*, const T*,
-                                    const typename geom_type<T>::value_type*,
-                                    const int*, const std::uint8_t*))fn_addr;
-                    auto _x_ref = xt::adapt(X.data(), {X.shape(0), X.shape(1)});
-                    return dolfinx::fem::Expression<T>(
-                        coefficients, constants, _x_ref,
-                        tabulate_expression_ptr, value_shape, mesh,
-                        argument_function_space);
-                  }),
-              py::arg("coefficients"), py::arg("constants"), py::arg("X"),
-              py::arg("fn"), py::arg("value_shape"), py::arg("mesh"),
-              py::arg("argument_function_space"))
+          .def(py::init(
+                   [](const std::vector<std::shared_ptr<
+                          const dolfinx::fem::Function<T>>>& coefficients,
+                      const std::vector<std::shared_ptr<
+                          const dolfinx::fem::Constant<T>>>& constants,
+                      const py::array_t<double, py::array::c_style>& X,
+                      std::uintptr_t fn_addr,
+                      const std::vector<int>& value_shape,
+                      const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh,
+                      const std::shared_ptr<const dolfinx::fem::FunctionSpace>&
+                          argument_function_space)
+                   {
+                     auto tabulate_expression_ptr
+                         = (void (*)(T*, const T*, const T*,
+                                     const typename geom_type<T>::value_type*,
+                                     const int*, const std::uint8_t*))fn_addr;
+                     return dolfinx::fem::Expression<T>(
+                         coefficients, constants, std::span(X.data(), X.size()),
+                         {static_cast<std::size_t>(X.shape(0)),
+                          static_cast<std::size_t>(X.shape(1))},
+                         tabulate_expression_ptr, value_shape, mesh,
+                         argument_function_space);
+                   }),
+               py::arg("coefficients"), py::arg("constants"), py::arg("X"),
+               py::arg("fn"), py::arg("value_shape"), py::arg("mesh"),
+               py::arg("argument_function_space"))
           .def(
               "eval",
               [](const dolfinx::fem::Expression<T>& self,
-                 const py::
-                     array_t<std::int32_t, py::array::c_style>& active_cells,
+                 const py::array_t<std::int32_t,
+                                   py::array::c_style>& active_cells,
                  py::array_t<T, py::array::c_style>& values)
               {
                 const int size = values.shape(0) * values.shape(1);
@@ -541,10 +538,16 @@ void declare_objects(py::module& m, const std::string& type)
                     const_cast<T*>(values.data()), size, xt::no_ownership(),
                     std::array<std::size_t, 2>({(std::size_t)values.shape(0),
                                                 (std::size_t)values.shape(1)}));
-                self.eval(xtl::span(active_cells.data(), active_cells.size()),
+                self.eval(std::span(active_cells.data(), active_cells.size()),
                           _values);
               },
               py::arg("active_cells"), py::arg("values"))
+          .def("X",
+               [](const dolfinx::fem::Expression<T>& self)
+               {
+                 auto [X, shape] = self.X();
+                 return dolfinx_wrappers::as_pyarray(std::move(X), shape);
+               })
           .def_property_readonly("dtype",
                                  [](const dolfinx::fem::Expression<T>& self)
                                  { return py::dtype::of<T>(); })
@@ -552,15 +555,7 @@ void declare_objects(py::module& m, const std::string& type)
           .def_property_readonly("value_size",
                                  &dolfinx::fem::Expression<T>::value_size)
           .def_property_readonly("value_shape",
-                                 &dolfinx::
-                                     fem::Expression<T>::value_shape)
-          .def_property_readonly("X",
-                                 [](const dolfinx::fem::Expression<T>& self)
-                                 {
-                                   return py::array_t<double>(self.X().shape(),
-                                                              self.X().data(),
-                                                              py::cast(self));
-                                 });
+                                 &dolfinx::fem::Expression<T>::value_shape);
 
   std::string pymethod_create_expression
       = std::string("create_expression_") + type;
@@ -624,14 +619,16 @@ void petsc_module(py::module& m)
           auto set_fn = dolfinx::la::petsc::Matrix::set_block_expand_fn(
               A, a.function_spaces()[0]->dofmap()->bs(),
               a.function_spaces()[1]->dofmap()->bs(), ADD_VALUES);
-          dolfinx::fem::assemble_matrix(set_fn, a, xtl::span(constants),
-                                        py_to_cpp_coeffs(coefficients), bcs);
+          dolfinx::fem::assemble_matrix(
+              set_fn, a, std::span(constants.data(), constants.size()),
+              py_to_cpp_coeffs(coefficients), bcs);
         }
         else
         {
           dolfinx::fem::assemble_matrix(
               dolfinx::la::petsc::Matrix::set_block_fn(A, ADD_VALUES), a,
-              xtl::span(constants), py_to_cpp_coeffs(coefficients), bcs);
+              std::span(constants.data(), constants.size()),
+              py_to_cpp_coeffs(coefficients), bcs);
         }
       },
       py::arg("A"), py::arg("a"), py::arg("constants"), py::arg("coeffs"),
@@ -654,9 +651,9 @@ void petsc_module(py::module& m)
               "Expected 1D arrays for boundary condition rows/columns");
         }
 
-        std::function<int(const xtl::span<const std::int32_t>&,
-                          const xtl::span<const std::int32_t>&,
-                          const xtl::span<const PetscScalar>&)>
+        std::function<int(const std::span<const std::int32_t>&,
+                          const std::span<const std::int32_t>&,
+                          const std::span<const PetscScalar>&)>
             set_fn;
         if (unrolled)
         {
@@ -667,9 +664,11 @@ void petsc_module(py::module& m)
         else
           set_fn = dolfinx::la::petsc::Matrix::set_block_fn(A, ADD_VALUES);
 
-        dolfinx::fem::assemble_matrix(set_fn, a, xtl::span(constants),
-                                      py_to_cpp_coeffs(coefficients), rows0,
-                                      rows1);
+        dolfinx::fem::assemble_matrix(
+            set_fn, a, std::span(constants.data(), constants.size()),
+            py_to_cpp_coeffs(coefficients),
+            std::span(rows0.data(), rows0.size()),
+            std::span(rows1.data(), rows1.size()));
       },
       py::arg("A"), py::arg("a"), py::arg("constants"), py::arg("coeffs"),
       py::arg("rows0"), py::arg("rows1"), py::arg("unrolled") = false);
@@ -931,10 +930,10 @@ void fem(py::module& m)
   declare_objects<std::complex<float>>(m, "complex64");
   declare_objects<std::complex<double>>(m, "complex128");
 
-  declare_form<double>(m, "float64");
   declare_form<float>(m, "float32");
-  declare_form<std::complex<double>>(m, "complex128");
+  declare_form<double>(m, "float64");
   declare_form<std::complex<float>>(m, "complex64");
+  declare_form<std::complex<double>>(m, "complex128");
 
   m.def(
       "create_sparsity_pattern",
@@ -1015,9 +1014,12 @@ void fem(py::module& m)
                              py::return_value_policy::reference_internal)
       .def_property_readonly("num_sub_elements",
                              &dolfinx::fem::FiniteElement::num_sub_elements)
-      .def_property_readonly(
-          "interpolation_points", [](const dolfinx::fem::FiniteElement& self)
-          { return xt_as_pyarray(self.interpolation_points()); })
+      .def("interpolation_points",
+           [](const dolfinx::fem::FiniteElement& self)
+           {
+             auto [X, shape] = self.interpolation_points();
+             return as_pyarray(std::move(X), shape);
+           })
       .def_property_readonly("interpolation_ident",
                              &dolfinx::fem::FiniteElement::interpolation_ident)
       .def_property_readonly("space_dimension",
@@ -1026,7 +1028,7 @@ void fem(py::module& m)
           "value_shape",
           [](const dolfinx::fem::FiniteElement& self)
           {
-            xtl::span<const std::size_t> shape = self.value_shape();
+            std::span<const std::size_t> shape = self.value_shape();
             return py::array_t(shape.size(), shape.data(), py::none());
           })
       .def(
@@ -1035,7 +1037,7 @@ void fem(py::module& m)
              py::array_t<double, py::array::c_style>& x,
              std::uint32_t cell_permutation, int dim)
           {
-            self.apply_dof_transformation(xtl::span(x.mutable_data(), x.size()),
+            self.apply_dof_transformation(std::span(x.mutable_data(), x.size()),
                                           cell_permutation, dim);
           },
           py::arg("x"), py::arg("cell_permutation"), py::arg("dim"))
@@ -1087,7 +1089,7 @@ void fem(py::module& m)
           "cell_dofs",
           [](const dolfinx::fem::DofMap& self, int cell)
           {
-            xtl::span<const std::int32_t> dofs = self.cell_dofs(cell);
+            std::span<const std::int32_t> dofs = self.cell_dofs(cell);
             return py::array_t<std::int32_t>(dofs.size(), dofs.data(),
                                              py::cast(self));
           },
@@ -1109,24 +1111,36 @@ void fem(py::module& m)
           "push_forward",
           [](const dolfinx::fem::CoordinateElement& self,
              const py::array_t<double, py::array::c_style>& X,
-             const py::array_t<double, py::array::c_style>& cell_geometry)
+             const py::array_t<double, py::array::c_style>& cell)
           {
-            std::array<std::size_t, 2> s_x;
-            std::copy_n(X.shape(), 2, s_x.begin());
-            auto _X = xt::adapt(X.data(), X.size(), xt::no_ownership(), s_x);
+            namespace stdex = std::experimental;
+            using mdspan2_t
+                = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+            using cmdspan2_t
+                = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+            using cmdspan4_t
+                = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
 
-            std::array<std::size_t, 2> s_g;
-            std::copy_n(cell_geometry.shape(), 2, s_g.begin());
-            auto g = xt::adapt(cell_geometry.data(), cell_geometry.size(),
-                               xt::no_ownership(), s_g);
+            std::array<std::size_t, 2> Xshape
+                = {(std::size_t)X.shape(0), (std::size_t)X.shape(1)};
 
-            xt::xtensor<double, 2> x = xt::empty<double>(
-                {_X.shape(0), std::size_t(cell_geometry.shape(1))});
-            const xt::xtensor<double, 2> phi
-                = xt::view(self.tabulate(0, _X), 0, xt::all(), xt::all(), 0);
+            std::array<std::size_t, 4> phi_shape
+                = self.tabulate_shape(0, X.shape(0));
+            std::vector<double> phi_b(std::reduce(
+                phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+            cmdspan4_t phi_full(phi_b.data(), phi_shape);
+            self.tabulate(0, std::span(X.data(), X.size()), Xshape, phi_b);
+            auto phi = stdex::submdspan(phi_full, 0, stdex::full_extent,
+                                        stdex::full_extent, 0);
 
-            self.push_forward(x, g, phi);
-            return xt_as_pyarray(std::move(x));
+            std::array<std::size_t, 2> shape
+                = {(std::size_t)X.shape(0), (std::size_t)cell.shape(1)};
+            std::vector<double> xb(shape[0] * shape[1]);
+            self.push_forward(
+                mdspan2_t(xb.data(), shape),
+                cmdspan2_t(cell.data(), cell.shape(0), cell.shape(1)), phi);
+
+            return as_pyarray(std::move(xb), shape);
           },
           py::arg("X"), py::arg("cell_geometry"))
       .def(
@@ -1139,35 +1153,47 @@ void fem(py::module& m)
             const std::size_t gdim = x.shape(1);
             const std::size_t tdim = dolfinx::mesh::cell_dim(self.cell_shape());
 
-            xt::xtensor<double, 2> X = xt::empty<double>({num_points, tdim});
+            namespace stdex = std::experimental;
+            using mdspan2_t
+                = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+            using cmdspan2_t
+                = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+            using cmdspan4_t
+                = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
 
-            std::array<std::size_t, 2> s_x;
-            std::copy_n(x.shape(), 2, s_x.begin());
-            auto _x = xt::adapt(x.data(), x.size(), xt::no_ownership(), s_x);
-
-            std::array<std::size_t, 2> s_g;
-            std::copy_n(cell_geometry.shape(), 2, s_g.begin());
-            auto g = xt::adapt(cell_geometry.data(), cell_geometry.size(),
-                               xt::no_ownership(), s_g);
+            std::vector<double> Xb(num_points * tdim);
+            mdspan2_t X(Xb.data(), num_points, tdim);
+            cmdspan2_t _x(x.data(), x.shape(0), x.shape(1));
+            cmdspan2_t g(cell_geometry.data(), cell_geometry.shape(0),
+                         cell_geometry.shape(1));
 
             if (self.is_affine())
             {
-              xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-              xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
-              xt::xtensor<double, 4> data(self.tabulate_shape(1, 1));
-              const xt::xtensor<double, 2> X0
-                  = xt::zeros<double>({std::size_t(1), tdim});
-              self.tabulate(1, X0, data);
-              xt::xtensor<double, 2> dphi
-                  = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
+              std::vector<double> J_b(gdim * tdim);
+              mdspan2_t J(J_b.data(), gdim, tdim);
+              std::vector<double> K_b(tdim * gdim);
+              mdspan2_t K(K_b.data(), tdim, gdim);
+
+              std::array<std::size_t, 4> phi_shape = self.tabulate_shape(1, 1);
+              std::vector<double> phi_b(std::reduce(
+                  phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+              cmdspan4_t phi(phi_b.data(), phi_shape);
+
+              self.tabulate(1, std::vector<double>(tdim), {1, tdim}, phi_b);
+              auto dphi = stdex::submdspan(phi, std::pair(1, tdim + 1), 0,
+                                           stdex::full_extent, 0);
+
               self.compute_jacobian(dphi, g, J);
               self.compute_jacobian_inverse(J, K);
-              self.pull_back_affine(X, K, self.x0(g), _x);
+              std::array<double, 3> x0 = {0, 0, 0};
+              for (std::size_t i = 0; i < g.extent(1); ++i)
+                x0[i] += g(0, i);
+              self.pull_back_affine(X, K, x0, _x);
             }
             else
               self.pull_back_nonaffine(X, _x, g);
 
-            return xt_as_pyarray(std::move(X));
+            return as_pyarray(std::move(Xb), std::array{num_points, tdim});
           },
           py::arg("x"), py::arg("cell_geometry"));
 
@@ -1188,7 +1214,7 @@ void fem(py::module& m)
           throw std::runtime_error("Expected two function spaces.");
         std::array<std::vector<std::int32_t>, 2> dofs
             = dolfinx::fem::locate_dofs_topological(
-                {V[0], V[1]}, dim, xtl::span(entities.data(), entities.size()),
+                {V[0], V[1]}, dim, std::span(entities.data(), entities.size()),
                 remote);
         return {as_pyarray(std::move(dofs[0])), as_pyarray(std::move(dofs[1]))};
       },
@@ -1201,7 +1227,7 @@ void fem(py::module& m)
          bool remote)
       {
         return as_pyarray(dolfinx::fem::locate_dofs_topological(
-            V, dim, xtl::span(entities.data(), entities.size()), remote));
+            V, dim, std::span(entities.data(), entities.size()), remote));
       },
       py::arg("V"), py::arg("dim"), py::arg("entities"),
       py::arg("remote") = true);

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -15,9 +15,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xtensor.hpp>
-#include <xtl/xspan.hpp>
+#include <span>
 
 namespace py = pybind11;
 
@@ -32,7 +30,7 @@ void geometry(py::module& m)
       {
         return dolfinx::geometry::create_midpoint_tree(
             mesh, tdim,
-            xtl::span<const std::int32_t>(entities.data(), entities.size()));
+            std::span<const std::int32_t>(entities.data(), entities.size()));
       },
       py::arg("mesh"), py::arg("tdim"), py::arg("entities"));
 
@@ -44,19 +42,18 @@ void geometry(py::module& m)
          const py::array_t<double, py::array::c_style>& points)
       {
         const std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
-        xt::xtensor<double, 2> p
-            = xt::zeros<double>({p_s0, static_cast<std::size_t>(3)});
+        std::vector<double> p(3 * p_s0);
         auto px = points.unchecked();
         if (px.ndim() == 1)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
-            p(0, i) = px(i);
+            p[i] = px(i);
         }
         else if (px.ndim() == 2)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
             for (py::ssize_t j = 0; j < px.shape(1); j++)
-              p(i, j) = px(i, j);
+              p[3 * i + j] = px(i, j);
         }
         else
           throw std::runtime_error("Array has wrong ndim.");
@@ -96,19 +93,18 @@ void geometry(py::module& m)
          const py::array_t<double>& points)
       {
         const std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
-        xt::xtensor<double, 2> _p
-            = xt::zeros<double>({p_s0, static_cast<std::size_t>(3)});
+        std::vector<double> _p(3 * p_s0);
         auto px = points.unchecked();
         if (px.ndim() == 1)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
-            _p(0, i) = px(i);
+            _p[i] = px(i);
         }
         else if (px.ndim() == 2)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
             for (py::ssize_t j = 0; j < px.shape(1); j++)
-              _p(i, j) = px(i, j);
+              _p[3 * i + j] = px(i, j);
         }
         else
           throw std::runtime_error("Array has wrong ndim.");
@@ -128,22 +124,20 @@ void geometry(py::module& m)
       {
         const std::size_t p_s0 = p.ndim() == 1 ? 1 : p.shape(0);
         const std::size_t q_s0 = q.ndim() == 1 ? 1 : q.shape(0);
-        xt::xtensor<double, 2> _p
-            = xt::zeros<double>({p_s0, static_cast<std::size_t>(3)});
-        xt::xtensor<double, 2> _q
-            = xt::zeros<double>({q_s0, static_cast<std::size_t>(3)});
+        std::vector<double> _p(3 * p_s0);
+        std::vector<double> _q(3 * q_s0);
 
         auto px = p.unchecked();
         if (px.ndim() == 1)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
-            _p(0, i) = px(i);
+            _p[i] = px(i);
         }
         else if (px.ndim() == 2)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
             for (py::ssize_t j = 0; j < px.shape(1); j++)
-              _p(i, j) = px(i, j);
+              _p[3 * i + j] = px(i, j);
         }
         else
           throw std::runtime_error("Array has wrong ndim.");
@@ -152,20 +146,20 @@ void geometry(py::module& m)
         if (qx.ndim() == 1)
         {
           for (py::ssize_t i = 0; i < qx.shape(0); i++)
-            _q(0, i) = qx(i);
+            _q[i] = qx(i);
         }
         else if (qx.ndim() == 2)
         {
           for (py::ssize_t i = 0; i < qx.shape(0); i++)
             for (py::ssize_t j = 0; j < qx.shape(1); j++)
-              _q(i, j) = qx(i, j);
+              _q[3 * i + j] = qx(i, j);
         }
         else
           throw std::runtime_error("Array has wrong ndim.");
 
-        const xt::xtensor_fixed<double, xt::xshape<3>> d
+        const std::array<double, 3> d
             = dolfinx::geometry::compute_distance_gjk(_p, _q);
-        return py::array_t<double>(d.shape(), d.data());
+        return py::array_t<double>(3, d.data());
       },
       py::arg("p"), py::arg("q"));
 
@@ -175,24 +169,23 @@ void geometry(py::module& m)
          std::vector<std::int32_t> indices, const py::array_t<double>& points)
       {
         const std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
-        xt::xtensor<double, 2> _p
-            = xt::zeros<double>({p_s0, static_cast<std::size_t>(3)});
+        std::vector<double> _p(3 * p_s0);
         auto px = points.unchecked();
         if (px.ndim() == 1)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
-            _p(0, i) = px(i);
+            _p[i] = px(i);
         }
         else if (px.ndim() == 2)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
             for (py::ssize_t j = 0; j < px.shape(1); j++)
-              _p(i, j) = px(i, j);
+              _p[3 * i + j] = px(i, j);
         }
         else
           throw std::runtime_error("Array has wrong ndim.");
 
-        return xt_as_pyarray(
+        return as_pyarray(
             dolfinx::geometry::squared_distance(mesh, dim, indices, _p));
       },
       py::arg("mesh"), py::arg("dim"), py::arg("indices"), py::arg("points"));
@@ -206,14 +199,14 @@ void geometry(py::module& m)
       {
         const int gdim = mesh.geometry().dim();
         std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
-        xt::xtensor<double, 2> _p = xt::zeros<double>({p_s0, std::size_t(3)});
+        std::vector<double> _p(3 * p_s0);
         auto px = points.unchecked();
         if (gdim > 1 and px.ndim() == 1)
         {
           // Single point in 2D/3D
           assert(px.shape(0) <= 3);
           for (py::ssize_t i = 0; i < px.shape(0); i++)
-            _p(0, i) = px(i);
+            _p[i] = px(i);
           auto cells = dolfinx::geometry::compute_colliding_cells(
               mesh, candidate_cells, _p);
           return py::array_t<std::int32_t>(cells.array().size(),
@@ -223,13 +216,13 @@ void geometry(py::module& m)
         {
           // 1D problem
           for (py::ssize_t i = 0; i < px.shape(0); i++)
-            _p(i, 0) = px(i);
+            _p[3 * i] = px(i);
         }
         else if (px.ndim() == 2)
         {
           for (py::ssize_t i = 0; i < px.shape(0); i++)
             for (py::ssize_t j = 0; j < px.shape(1); j++)
-              _p(i, j) = px(i, j);
+              _p[3 * i + j] = px(i, j);
         }
         else
           throw std::runtime_error("Array has wrong ndim.");
@@ -250,7 +243,7 @@ void geometry(py::module& m)
                {
                  return dolfinx::geometry::BoundingBoxTree(
                      mesh, dim,
-                     xtl::span<const std::int32_t>(entities.data(),
+                     std::span<const std::int32_t>(entities.data(),
                                                    entities.size()),
                      padding);
                }),
@@ -261,11 +254,7 @@ void geometry(py::module& m)
       .def(
           "get_bbox",
           [](const dolfinx::geometry::BoundingBoxTree& self,
-             const std::size_t i)
-          {
-            xt::xtensor<double, 2> bbox = self.get_bbox(i);
-            return xt_as_pyarray(std::move(bbox));
-          },
+             const std::size_t i) { return self.get_bbox(i); },
           py::arg("i"))
       .def("__repr__", &dolfinx::geometry::BoundingBoxTree::str)
       .def(

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -67,7 +67,7 @@ void declare_adjacency_list(py::module& m, std::string type)
           "links",
           [](const dolfinx::graph::AdjacencyList<T>& self, int i)
           {
-            xtl::span<const T> link = self.links(i);
+            std::span<const T> link = self.links(i);
             return py::array_t<T>(link.size(), link.data(), py::cast(self));
           },
           py::arg("i"), "Links (edges) of a node")

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -42,7 +42,10 @@ void io(py::module& m)
   m.def(
       "extract_vtk_connectivity",
       [](const dolfinx::mesh::Mesh& mesh)
-      { return xt_as_pyarray(dolfinx::io::extract_vtk_connectivity(mesh)); },
+      {
+        auto [cells, shape] = dolfinx::io::extract_vtk_connectivity(mesh);
+        return as_pyarray(std::move(cells), shape);
+      },
       py::arg("mesh"),
       "Extract the mesh topology with VTK ordering using geometry indices");
 
@@ -66,8 +69,8 @@ void io(py::module& m)
         assert(entities.shape(0) == values.shape(0));
         std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
             entities_values = dolfinx::io::xdmf_utils::distribute_entity_data(
-                mesh, entity_dim, xtl::span(entities.data(), entities.size()),
-                xtl::span(values.data(), values.size()));
+                mesh, entity_dim, std::span(entities.data(), entities.size()),
+                std::span(values.data(), values.size()));
 
         std::size_t num_vert_per_entity = dolfinx::mesh::cell_num_entities(
             dolfinx::mesh::cell_entity_type(mesh.topology().cell_type(),

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -26,7 +26,6 @@
 #include <pybind11/stl/filesystem.h>
 #include <string>
 #include <vector>
-#include <xtensor/xadapt.hpp>
 
 namespace py = pybind11;
 
@@ -116,13 +115,19 @@ void io(py::module& m)
           "read_topology_data",
           [](dolfinx::io::XDMFFile& self, const std::string& name,
              const std::string& xpath)
-          { return xt_as_pyarray(self.read_topology_data(name, xpath)); },
+          {
+            auto [cells, shape] = self.read_topology_data(name, xpath);
+            return as_pyarray(std::move(cells), shape);
+          },
           py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
       .def(
           "read_geometry_data",
           [](dolfinx::io::XDMFFile& self, const std::string& name,
              const std::string& xpath)
-          { return xt_as_pyarray(self.read_geometry_data(name, xpath)); },
+          {
+            auto [x, shape] = self.read_geometry_data(name, xpath);
+            return as_pyarray(std::move(x), shape);
+          },
           py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
       .def("read_geometry_data", &dolfinx::io::XDMFFile::read_geometry_data,
            py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -20,7 +20,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <xtl/xspan.hpp>
+#include <span>
 
 namespace py = pybind11;
 
@@ -61,7 +61,7 @@ void declare_objects(py::module& m, const std::string& type)
       .def_property_readonly("array",
                              [](dolfinx::la::Vector<T>& self)
                              {
-                               xtl::span<T> array = self.mutable_array();
+                               std::span<T> array = self.mutable_array();
                                return py::array_t<T>(array.size(), array.data(),
                                                      py::cast(self));
                              })
@@ -114,14 +114,14 @@ void declare_objects(py::module& m, const std::string& type)
       .def_property_readonly("data",
                              [](dolfinx::la::MatrixCSR<T>& self)
                              {
-                               xtl::span<T> array = self.values();
+                               std::span<T> array = self.values();
                                return py::array_t<T>(array.size(), array.data(),
                                                      py::cast(self));
                              })
       .def_property_readonly("indices",
                              [](dolfinx::la::MatrixCSR<T>& self)
                              {
-                               xtl::span<const std::int32_t> array
+                               std::span<const std::int32_t> array
                                    = self.cols();
                                return py::array_t<const std::int32_t>(
                                    array.size(), array.data(), py::cast(self));
@@ -129,7 +129,7 @@ void declare_objects(py::module& m, const std::string& type)
       .def_property_readonly("indptr",
                              [](dolfinx::la::MatrixCSR<T>& self)
                              {
-                               xtl::span<const std::int32_t> array
+                               std::span<const std::int32_t> array
                                    = self.row_ptr();
                                return py::array_t<const std::int32_t>(
                                    array.size(), array.data(), py::cast(self));
@@ -172,7 +172,7 @@ void petsc_module(py::module& m)
              std::reference_wrapper<const dolfinx::common::IndexMap>, int>>&
              maps)
       {
-        std::vector<xtl::span<const PetscScalar>> _x_b;
+        std::vector<std::span<const PetscScalar>> _x_b;
         for (auto& array : x_b)
           _x_b.emplace_back(array.data(), array.size());
         dolfinx::la::petsc::scatter_local_vectors(x, _x_b, maps);
@@ -258,15 +258,15 @@ void la(py::module& m)
              const py::array_t<std::int32_t, py::array::c_style>& rows,
              const py::array_t<std::int32_t, py::array::c_style>& cols)
           {
-            self.insert(xtl::span(rows.data(), rows.size()),
-                        xtl::span(cols.data(), cols.size()));
+            self.insert(std::span(rows.data(), rows.size()),
+                        std::span(cols.data(), cols.size()));
           },
           py::arg("rows"), py::arg("cols"))
       .def(
           "insert_diagonal",
           [](dolfinx::la::SparsityPattern& self,
              const py::array_t<std::int32_t, py::array::c_style>& rows)
-          { self.insert_diagonal(rows); },
+          { self.insert_diagonal(std::span(rows.data(), rows.size())); },
           py::arg("rows"))
       .def_property_readonly("graph", &dolfinx::la::SparsityPattern::graph,
                              py::return_value_policy::reference_internal);

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -28,8 +28,8 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <span>
 #include <xtensor/xadapt.hpp>
-#include <xtl/xspan.hpp>
 
 namespace py = pybind11;
 
@@ -133,7 +133,7 @@ void declare_meshtags(py::module& m, std::string type)
            const py::array_t<T, py::array::c_style>& values)
         {
           return dolfinx::mesh::create_meshtags(
-              mesh, dim, entities, xtl::span(values.data(), values.size()));
+              mesh, dim, entities, std::span(values.data(), values.size()));
         });
 }
 
@@ -167,7 +167,7 @@ void mesh(py::module& m)
          const py::array_t<std::int32_t, py::array::c_style>& entities)
       {
         std::vector<double> n = dolfinx::mesh::cell_normals(
-            mesh, dim, xtl::span(entities.data(), entities.size()));
+            mesh, dim, std::span(entities.data(), entities.size()));
         return as_pyarray(std::move(n),
                           std::array<std::size_t, 2>{n.size() / 3, 3});
       },
@@ -183,7 +183,7 @@ void mesh(py::module& m)
          const py::array_t<std::int32_t, py::array::c_style>& entities)
       {
         return as_pyarray(dolfinx::mesh::h(
-            mesh, xtl::span(entities.data(), entities.size()), dim));
+            mesh, std::span(entities.data(), entities.size()), dim));
       },
       py::arg("mesh"), py::arg("dim"), py::arg("entities"),
       "Compute maximum distance between any two vertices.");
@@ -194,7 +194,7 @@ void mesh(py::module& m)
          py::array_t<std::int32_t, py::array::c_style> entities)
       {
         std::vector<double> x = dolfinx::mesh::compute_midpoints(
-            mesh, dim, xtl::span(entities.data(), entities.size()));
+            mesh, dim, std::span(entities.data(), entities.size()));
         std::array<std::size_t, 2> shape = {(std::size_t)entities.size(), 3};
         return as_pyarray(std::move(x), shape);
       },
@@ -248,7 +248,7 @@ void mesh(py::module& m)
          const py::array_t<std::int32_t, py::array::c_style>& entities)
       {
         return dolfinx::mesh::create_submesh(
-            mesh, dim, xtl::span(entities.data(), entities.size()));
+            mesh, dim, std::span(entities.data(), entities.size()));
       },
       py::arg("mesh"), py::arg("dim"), py::arg("entities"));
 
@@ -438,8 +438,8 @@ void mesh(py::module& m)
       [](const dolfinx::mesh::Mesh& mesh, int dim,
          py::array_t<std::int32_t, py::array::c_style> entities, bool orient)
       {
-        std::vector<std::int32_t> idx
-            = dolfinx::mesh::entities_to_geometry(mesh, dim, entities, orient);
+        std::vector<std::int32_t> idx = dolfinx::mesh::entities_to_geometry(
+            mesh, dim, std::span(entities.data(), entities.size()), orient);
         dolfinx::mesh::CellType cell_type = mesh.topology().cell_type();
         std::size_t num_vertices = dolfinx::mesh::num_cell_vertices(
             cell_entity_type(cell_type, dim, 0));
@@ -459,7 +459,7 @@ void mesh(py::module& m)
          py::array_t<std::int32_t, py::array::c_style> entities, int d0, int d1)
       {
         return as_pyarray(dolfinx::mesh::compute_incident_entities(
-            mesh, xtl::span(entities.data(), entities.size()), d0, d1));
+            mesh, std::span(entities.data(), entities.size()), d0, d1));
       },
       py::arg("mesh"), py::arg("entities"), py::arg("d0"), py::arg("d1"));
 

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -235,8 +235,11 @@ void mesh(py::module& m)
         std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape()[1];
         std::vector shape{std::size_t(x.shape(0)), shape1};
         auto _x = xt::adapt(x.data(), x.size(), xt::no_ownership(), shape);
-        return dolfinx::mesh::create_mesh(comm.get(), cells, element, _x,
-                                          ghost_mode, partitioner_wrapper);
+        return dolfinx::mesh::create_mesh(
+            comm.get(), cells, element, std::span(x.data(), x.size()),
+            {static_cast<std::size_t>(x.shape(0)),
+             static_cast<std::size_t>(x.shape(1))},
+            ghost_mode, partitioner_wrapper);
       },
       py::arg("comm"), py::arg("cells"), py::arg("element"), py::arg("x"),
       py::arg("ghost_mode"), py::arg("partitioner"),

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -58,7 +58,7 @@ void refinement(py::module& m)
       {
         assert(edges.ndim() == 1);
         return dolfinx::refinement::refine(
-            mesh, xtl::span(edges.data(), edges.size()), redistribute);
+            mesh, std::span(edges.data(), edges.size()), redistribute);
       },
       py::arg("mesh"), py::arg("edges"), py::arg("redistribute") = true);
 }

--- a/python/test/unit/common/test_mpi.py
+++ b/python/test/unit/common/test_mpi.py
@@ -43,7 +43,7 @@ def test_mpi_comm_wrapper_cppimport(tempdir):  # noqa: F811
 /*
 <%
 setup_pybind11(cfg)
-cfg['compiler_args'] = ['-std=c++17']
+cfg['compiler_args'] = ['-std=c++20']
 cfg['include_dirs'] += {dolfinx_pc["include_dirs"]
                         + [mpi4py.get_include()]
                         + [str(wrappers.get_include_path())]}

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -42,7 +42,7 @@ def test_eigen_assembly(tempdir):  # noqa: F811
 setup_pybind11(cfg)
 cfg['include_dirs'] = {dolfinx_pc["include_dirs"] + [petsc4py.get_include()]
   + [pybind11.get_include()] + [str(pybind_inc())] + eigen_dir}
-cfg['compiler_args'] = ["-std=c++17", "-Wno-comment"]
+cfg['compiler_args'] = ["-std=c++20", "-Wno-comment"]
 cfg['libraries'] = {dolfinx_pc["libraries"]}
 cfg['library_dirs'] = {dolfinx_pc["library_dirs"]}
 %>
@@ -66,9 +66,9 @@ assemble_csr(const dolfinx::fem::Form<T>& a,
 {
   std::vector<Eigen::Triplet<T>> triplets;
   auto mat_add
-      = [&triplets](const xtl::span<const std::int32_t>& rows,
-                    const xtl::span<const std::int32_t>& cols,
-                    const xtl::span<const T>& v)
+      = [&triplets](const std::span<const std::int32_t>& rows,
+                    const std::span<const std::int32_t>& cols,
+                    const std::span<const T>& v)
     {
       for (std::size_t i = 0; i < rows.size(); ++i)
         for (std::size_t j = 0; j < cols.size(); ++j)

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -100,10 +100,12 @@ def test_overlapping_bcs():
 
 
 @pytest.mark.parametrize('mesh_factory',
-                         [(create_unit_square, (MPI.COMM_WORLD, 4, 4)),
-                          (create_unit_square, (MPI.COMM_WORLD, 4, 4, CellType.quadrilateral)),
-                          (create_unit_cube, (MPI.COMM_WORLD, 3, 3, 3)),
-                          (create_unit_cube, (MPI.COMM_WORLD, 3, 3, 3, CellType.hexahedron))])
+                         [
+                             (create_unit_square, (MPI.COMM_WORLD, 4, 4)),
+                             (create_unit_square, (MPI.COMM_WORLD, 4, 4, CellType.quadrilateral)),
+                             (create_unit_cube, (MPI.COMM_WORLD, 3, 3, 3)),
+                             (create_unit_cube, (MPI.COMM_WORLD, 3, 3, 3, CellType.hexahedron))
+                         ])
 def test_constant_bc(mesh_factory):
     """Test that setting a dirichletbc with a constant yields the same
     result as setting it with a function"""

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -77,7 +77,7 @@ def test_gradient_interpolation(cell_type, p, q):
     u = Function(V)
     u.interpolate(lambda x: 2 * x[0]**p + 3 * x[1]**p)
 
-    grad_u = Expression(ufl.grad(u), W.element.interpolation_points)
+    grad_u = Expression(ufl.grad(u), W.element.interpolation_points())
     w_expr = Function(W)
     w_expr.interpolate(grad_u)
 
@@ -92,10 +92,12 @@ def test_gradient_interpolation(cell_type, p, q):
 @pytest.mark.parametrize("p", range(1, 4))
 @pytest.mark.parametrize("q", range(1, 4))
 @pytest.mark.parametrize("from_lagrange", [True, False])
-@pytest.mark.parametrize("cell_type", [CellType.quadrilateral,
-                                       CellType.triangle,
-                                       CellType.tetrahedron,
-                                       CellType.hexahedron])
+@pytest.mark.parametrize("cell_type", [
+    CellType.quadrilateral,
+    CellType.triangle,
+    CellType.tetrahedron,
+    CellType.hexahedron
+])
 def test_interpolation_matrix(cell_type, p, q, from_lagrange):
     """Test that discrete interpolation matrix yields the same result as interpolation."""
 

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -10,8 +10,9 @@ import pytest
 
 import ufl
 from dolfinx.cpp.fem.petsc import discrete_gradient, interpolation_matrix
-from dolfinx.fem import Expression, Function, FunctionSpace
-from dolfinx.mesh import (CellType, GhostMode, create_unit_cube,
+from dolfinx.fem import (Expression, Function, FunctionSpace,
+                         VectorFunctionSpace, assemble_scalar, form)
+from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_unit_cube,
                           create_unit_square)
 
 from mpi4py import MPI
@@ -149,3 +150,41 @@ def test_interpolation_matrix(cell_type, p, q, from_lagrange):
     w.x.scatter_forward()
 
     assert np.allclose(w_vec.x.array, w.x.array)
+
+
+@pytest.mark.skip_in_parallel
+def test_nonaffine_discrete_operator():
+    """
+    Check that discrete operator is consistent with normal interpolation between non-matching
+    maps on non-affine geometries
+    """
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 2, 0], [1, 2, 0],
+                       [0, 0, 3], [1, 0, 3], [0, 2, 3], [1, 2, 3],
+                       [0.5, 0, 0], [0, 1, 0], [0, 0, 1.5], [1, 1, 0],
+                       [1, 0, 1.5], [0.5, 2, 0], [0, 2, 1.5], [1, 2, 1.5],
+                       [0.5, 0, 3], [0, 1, 3], [1, 1, 3], [0.5, 2, 3],
+                       [0.5, 1, 0], [0.5, -0.1, 1.5], [0, 1, 1.5], [1, 1, 1.5],
+                       [0.5, 2, 1.5], [0.5, 1, 3], [0.5, 1, 1.5]], dtype=np.float64)
+
+    cells = np.array([range(len(points))], dtype=np.int32)
+    cell_type = CellType.hexahedron
+    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell_type.name, 2))
+    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
+    W = VectorFunctionSpace(mesh, ("DG", 1))
+    V = FunctionSpace(mesh, ("NCE", 4))
+    w, v = Function(W), Function(V)
+    w.interpolate(lambda x: x)
+    v.interpolate(w)
+
+    G = interpolation_matrix(W._cpp_object, V._cpp_object)
+    G.assemble()
+
+    # Compute global matrix vector product
+    v_vec = Function(V)
+    G.mult(w.vector, v_vec.vector)
+    v_vec.x.scatter_forward()
+
+    assert np.allclose(v_vec.x.array, v.x.array)
+
+    s = assemble_scalar(form(ufl.inner(w - v, w - v) * ufl.dx))
+    assert np.isclose(s, 0)

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -126,7 +126,7 @@ def test_dof_positions(cell_type, space_type):
     entities = {i: {} for i in range(1, tdim)}
     for cell in range(coord_dofs.num_nodes):
         # Push coordinates forward
-        X = V.element.interpolation_points
+        X = V.element.interpolation_points()
         xg = x_g[coord_dofs.links(cell), :tdim]
         x = cmap.push_forward(X, xg)
 
@@ -217,7 +217,7 @@ def random_evaluation_mesh(cell_type):
 )
 @pytest.mark.parametrize('space_order', range(1, 4))
 def test_evaluation(cell_type, space_type, space_order):
-    if cell_type == "hexahedron" and space_order >= 3:
+    if cell_type == "hexahedron" and space_order > 3:
         pytest.skip("Skipping expensive test on hexahedron")
 
     random.seed(4)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -258,7 +258,7 @@ def test_higher_order_coordinate_map(points, celltype, order):
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
 
     V = FunctionSpace(mesh, ("Lagrange", 2))
-    X = V.element.interpolation_points
+    X = V.element.interpolation_points()
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
     cmap = mesh.geometry.cmap
@@ -306,7 +306,7 @@ def test_higher_order_tetra_coordinate_map(order):
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", celltype.name, order))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
     V = FunctionSpace(mesh, ("Lagrange", order))
-    X = V.element.interpolation_points
+    X = V.element.interpolation_points()
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
 

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -107,7 +107,7 @@ def test_rank0():
     f.interpolate(expr1)
 
     ufl_expr = ufl.grad(f)
-    points = vdP1.element.interpolation_points
+    points = vdP1.element.interpolation_points()
 
     compiled_expr = Expression(ufl_expr, points)
     num_cells = mesh.topology.index_map(2).size_local
@@ -147,7 +147,7 @@ def test_rank1_hdiv():
 
     f = ufl.TrialFunction(RT1)
 
-    points = vdP1.element.interpolation_points
+    points = vdP1.element.interpolation_points()
     compiled_expr = Expression(f, points)
 
     num_cells = mesh.topology.index_map(2).size_local
@@ -237,7 +237,7 @@ def test_simple_evaluation():
     ufl_grad_f = Constant(mesh, PETSc.ScalarType(3.0)) * ufl.grad(expr)
     points = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
     grad_f_expr = Expression(ufl_grad_f, points)
-    assert grad_f_expr.X.shape[0] == points.shape[0]
+    assert grad_f_expr.X().shape[0] == points.shape[0]
     assert grad_f_expr.value_size == 2
 
     # NOTE: Cell numbering is process local.
@@ -247,16 +247,16 @@ def test_simple_evaluation():
 
     grad_f_evaluated = grad_f_expr.eval(cells)
     assert grad_f_evaluated.shape[0] == cells.shape[0]
-    assert grad_f_evaluated.shape[1] == grad_f_expr.value_size * grad_f_expr.X.shape[0]
+    assert grad_f_evaluated.shape[1] == grad_f_expr.value_size * grad_f_expr.X().shape[0]
 
     # Evaluate points in global space
     ufl_x = ufl.SpatialCoordinate(mesh)
     x_expr = Expression(ufl_x, points)
-    assert x_expr.X.shape[0] == points.shape[0]
+    assert x_expr.X().shape[0] == points.shape[0]
     assert x_expr.value_size == 2
     x_evaluated = x_expr.eval(cells)
     assert x_evaluated.shape[0] == cells.shape[0]
-    assert x_evaluated.shape[1] == x_expr.X.shape[0] * x_expr.value_size
+    assert x_evaluated.shape[1] == x_expr.X().shape[0] * x_expr.value_size
 
     # Evaluate exact gradient using global points
     grad_f_exact = exact_grad_f(x_evaluated)
@@ -367,7 +367,7 @@ def test_expression_eval_cells_subset():
     u = dolfinx.fem.Function(V)
     u.x.array[:] = dofs_to_cells
     u.x.scatter_forward()
-    e = dolfinx.fem.Expression(u, V.element.interpolation_points)
+    e = dolfinx.fem.Expression(u, V.element.interpolation_points())
 
     # Test eval on single cell
     for c in range(cells_imap.size_local):

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -112,7 +112,7 @@ def test_sub(Q, W):
     assert W.element.num_sub_elements == X.element.num_sub_elements
     assert W.element.space_dimension == X.element.space_dimension
     assert W.element.value_shape == X.element.value_shape
-    assert W.element.interpolation_points.shape == X.element.interpolation_points.shape
+    assert W.element.interpolation_points().shape == X.element.interpolation_points().shape
     assert W.element == X.element
 
 

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -434,7 +434,7 @@ def test_nedelec_spatial(order, dim):
     # The expression (x,y,z) is contained in the N1curl function space
     # order>1
     f_ex = x
-    f = Expression(f_ex, V.element.interpolation_points)
+    f = Expression(f_ex, V.element.interpolation_points())
     u.interpolate(f)
     assert np.isclose(np.abs(assemble_scalar(form(ufl.inner(u - f_ex, u - f_ex) * ufl.dx))), 0)
 
@@ -442,7 +442,7 @@ def test_nedelec_spatial(order, dim):
     # order
     V2 = FunctionSpace(mesh, ("N2curl", 1))
     w = Function(V2)
-    f2 = Expression(f_ex, V2.element.interpolation_points)
+    f2 = Expression(f_ex, V2.element.interpolation_points())
     w.interpolate(f2)
     assert np.isclose(np.abs(assemble_scalar(form(ufl.inner(w - f_ex, w - f_ex) * ufl.dx))), 0)
 
@@ -464,7 +464,7 @@ def test_vector_interpolation_spatial(order, dim, affine):
 
     # The expression (x,y,z)^n is contained in space
     f = ufl.as_vector([x[i]**order for i in range(dim)])
-    u.interpolate(Expression(f, V.element.interpolation_points))
+    u.interpolate(Expression(f, V.element.interpolation_points()))
     assert np.isclose(np.abs(assemble_scalar(form(ufl.inner(u - f, u - f) * ufl.dx))), 0)
 
 
@@ -481,7 +481,7 @@ def test_2D_lagrange_to_curl(order):
     u1.interpolate(lambda x: x[0])
 
     f = ufl.as_vector((u0, u1))
-    f_expr = Expression(f, V.element.interpolation_points)
+    f_expr = Expression(f, V.element.interpolation_points())
     u.interpolate(f_expr)
     x = ufl.SpatialCoordinate(mesh)
     f_ex = ufl.as_vector((-x[1], x[0]))
@@ -498,7 +498,7 @@ def test_de_rahm_2D(order):
     g = ufl.grad(w)
     Q = FunctionSpace(mesh, ("N2curl", order - 1))
     q = Function(Q)
-    q.interpolate(Expression(g, Q.element.interpolation_points))
+    q.interpolate(Expression(g, Q.element.interpolation_points()))
 
     x = ufl.SpatialCoordinate(mesh)
     g_ex = ufl.as_vector((1 + x[1], 4 * x[1] + x[0]))
@@ -510,7 +510,7 @@ def test_de_rahm_2D(order):
     def curl2D(u):
         return ufl.as_vector((ufl.Dx(u[1], 0), - ufl.Dx(u[0], 1)))
 
-    v.interpolate(Expression(curl2D(ufl.grad(w)), V.element.interpolation_points))
+    v.interpolate(Expression(curl2D(ufl.grad(w)), V.element.interpolation_points()))
     h_ex = ufl.as_vector((1, -1))
     assert np.isclose(np.abs(assemble_scalar(form(ufl.inner(v - h_ex, v - h_ex) * ufl.dx))), 0)
 
@@ -535,7 +535,7 @@ def test_interpolate_subset(order, dim, affine):
 
     x = ufl.SpatialCoordinate(mesh)
     f = x[1]**order
-    expr = Expression(f, V.element.interpolation_points)
+    expr = Expression(f, V.element.interpolation_points())
     u.interpolate(expr, cells_local)
     mt = meshtags(mesh, mesh.topology.dim, cells_local, np.ones(cells_local.size, dtype=np.int32))
     dx = ufl.Measure("dx", domain=mesh, subdomain_data=mt)

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -419,6 +419,29 @@ def test_interpolation_non_affine():
     assert np.isclose(s, 0)
 
 
+@pytest.mark.skip_in_parallel
+def test_interpolation_non_affine_nonmatching_maps():
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 2, 0], [1, 2, 0],
+                       [0, 0, 3], [1, 0, 3], [0, 2, 3], [1, 2, 3],
+                       [0.5, 0, 0], [0, 1, 0], [0, 0, 1.5], [1, 1, 0],
+                       [1, 0, 1.5], [0.5, 2, 0], [0, 2, 1.5], [1, 2, 1.5],
+                       [0.5, 0, 3], [0, 1, 3], [1, 1, 3], [0.5, 2, 3],
+                       [0.5, 1, 0], [0.5, -0.1, 1.5], [0, 1, 1.5], [1, 1, 1.5],
+                       [0.5, 2, 1.5], [0.5, 1, 3], [0.5, 1, 1.5]], dtype=np.float64)
+
+    cells = np.array([range(len(points))], dtype=np.int32)
+    cell_type = CellType.hexahedron
+    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell_type.name, 2))
+    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
+    W = VectorFunctionSpace(mesh, ("DG", 1))
+    V = FunctionSpace(mesh, ("NCE", 4))
+    w, v = Function(W), Function(V)
+    w.interpolate(lambda x: x)
+    v.interpolate(w)
+    s = assemble_scalar(form(ufl.inner(w - v, w - v) * ufl.dx))
+    assert np.isclose(s, 0)
+
+
 @pytest.mark.parametrize("order", [2, 3, 4])
 @pytest.mark.parametrize("dim", [2, 3])
 def test_nedelec_spatial(order, dim):


### PR DESCRIPTION
Remove all xtensor from interpolation code.
Use mdspan for multidimensional views.
Various updates relating to comments by @garth-wells.